### PR TITLE
config file refactoring

### DIFF
--- a/src/MultiFactor.SelfService.Linux.Portal/Attributes/RequiredFeatureAttribute.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Attributes/RequiredFeatureAttribute.cs
@@ -26,7 +26,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Attributes
                 throw new FeatureNotEnabledException(ApplicationFeature.PasswordManagement.GetEnumDescription());
             }
 
-            if (_requiredFeatureFlags.HasFlag(ApplicationFeature.ExchangeActiveSyncDevicesManagement) && !configuration.EnableExchangeActiveSyncDevicesManagement)
+            if (_requiredFeatureFlags.HasFlag(ApplicationFeature.ExchangeActiveSyncDevicesManagement) && !configuration.ExchangeActiveSyncDevicesManagement!.Enabled)
             {
                 throw new FeatureNotEnabledException(ApplicationFeature.ExchangeActiveSyncDevicesManagement.GetEnumDescription());
             }

--- a/src/MultiFactor.SelfService.Linux.Portal/Core/Caching/CacheExtensions.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Core/Caching/CacheExtensions.cs
@@ -10,14 +10,14 @@ namespace MultiFactor.SelfService.Linux.Portal.Core.Caching
             services.AddMemoryCache(x =>
             {
                 // 5 Mb by default
-                x.SizeLimit = settings.PasswordChangingSession.CacheSize ?? 1024 * 1024 * 5;
+                x.SizeLimit = settings.PasswordChangingSessionCacheSize ?? 1024 * 1024 * 5;
             });
 
             services.Configure<ApplicationCacheConfig>(x =>
             {
-                if (settings.PasswordChangingSession.Lifetime != null)
+                if (settings.PasswordChangingSessionLifetime != null)
                 {
-                    x.AbsoluteExpiration = settings.PasswordChangingSession.Lifetime.Value;
+                    x.AbsoluteExpiration = settings.PasswordChangingSessionLifetime.Value;
                 }
             });
             services.AddSingleton<ApplicationCache>();

--- a/src/MultiFactor.SelfService.Linux.Portal/Extensions/ConfigurationRegistering.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Extensions/ConfigurationRegistering.cs
@@ -56,6 +56,24 @@ namespace MultiFactor.SelfService.Linux.Portal.Extensions
                     settings.PasswordChangingSessionSettings?.PwdChangingSessionCacheSize
                 );
             }
+
+            if (settings.ExchangeActiveSyncDevicesManagement == null)
+            {
+                settings.ExchangeActiveSyncDevicesManagement = new ExchangeActiveSyncDevicesManagement(
+                    settings.EnableExchangeActiveSyncDevicesManagement
+                );
+            }
+
+            if(settings.RequiresUserPrincipalName == true)
+            {
+                settings.ActiveDirectorySettings = new ActiveDirectorySettings(
+                    settings.ActiveDirectorySettings.SecondFactorGroup,
+                    settings.ActiveDirectorySettings.UseUserPhone,
+                    settings.ActiveDirectorySettings.UseMobileUserPhone,
+                    settings.ActiveDirectorySettings.NetBiosName,
+                    settings.RequiresUserPrincipalName
+                );
+            }
 #pragma warning restore CS0612
         }
 

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/MultiFactorApi/MultiFactorApi.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/MultiFactorApi/MultiFactorApi.cs
@@ -73,7 +73,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.MultiFactorApi
                 Policy = response.Policy,
 
                 EnablePasswordManagement = _settings.PasswordManagement!.Enabled,
-                EnableExchangeActiveSyncDevicesManagement = _settings.EnableExchangeActiveSyncDevicesManagement
+                EnableExchangeActiveSyncDevicesManagement = _settings.ExchangeActiveSyncDevicesManagement!.Enabled
             };
         }
 

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/ActiveDirectoryOptions.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/ActiveDirectoryOptions.cs
@@ -6,5 +6,21 @@
         public bool UseUserPhone { get; private set; }
         public bool UseMobileUserPhone { get; private set; }
         public string? NetBiosName { get; private set; }
+        public bool RequiresUserPrincipalName { get; private set; }
+
+        public ActiveDirectorySettings() { }
+        public ActiveDirectorySettings(
+            string? secondFactorGroup,
+            bool useUserPhone, 
+            bool useMobileUserPhone, 
+            string? netBiosName,
+            bool requiresUserPrincipalName)
+        {
+            SecondFactorGroup = secondFactorGroup;
+            UseUserPhone = useUserPhone;
+            UseMobileUserPhone = useMobileUserPhone;
+            NetBiosName = netBiosName;
+            RequiresUserPrincipalName = requiresUserPrincipalName;
+        }
     }
 }

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/ExchangeActiveSyncDevicesManagement.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/ExchangeActiveSyncDevicesManagement.cs
@@ -1,0 +1,13 @@
+﻿namespace MultiFactor.SelfService.Linux.Portal.Settings
+{
+    public class ExchangeActiveSyncDevicesManagement
+    { 
+        public bool Enabled { get; private set; } = false;
+
+        public ExchangeActiveSyncDevicesManagement() { }
+        public ExchangeActiveSyncDevicesManagement(bool enabled)
+        {
+            Enabled = enabled;
+        }
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordManagementSettings.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordManagementSettings.cs
@@ -8,7 +8,8 @@
             ChangePasswordMode.AsUser;
         public ChangePasswordMode ChangeExpiredPasswordMode { get; private set; } =
             ChangePasswordMode.AsTechnicalAccount;
-        public PasswordChangingSessionSettings PasswordChangingSession { get; private set; } = new();
+        public TimeSpan? PasswordChangingSessionLifetime { get; set; }
+        public long? PasswordChangingSessionCacheSize { get; set; }
 
         public PasswordManagementSettings() { }
         public PasswordManagementSettings(
@@ -23,8 +24,8 @@
             AllowPasswordRecovery = isPasswordRecoveryEnabled;
             ChangeValidPasswordMode = changeValidPwdMode;
             ChangeExpiredPasswordMode = changeExpiredPwdMode;
-            PasswordChangingSession.Lifetime = pwdChangingSessionLifetime;
-            PasswordChangingSession.CacheSize = pwdChangingSessionCacheSize;
+            PasswordChangingSessionLifetime = pwdChangingSessionLifetime;
+            PasswordChangingSessionCacheSize = pwdChangingSessionCacheSize;
         }
     }
 

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PortalSettings.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PortalSettings.cs
@@ -8,19 +8,20 @@ namespace MultiFactor.SelfService.Linux.Portal.Settings
 
         public CompanySettings CompanySettings { get; private set; } = new();
         public TechnicalAccountSettings TechnicalAccountSettings { get; private set; } = new();
-        public ActiveDirectorySettings ActiveDirectorySettings { get; private set; } = new();
+        public ActiveDirectorySettings ActiveDirectorySettings { get; set; } = new();
         public MultiFactorApiSettings MultiFactorApiSettings { get; private set; } = new();
         public GroupPolicyPreset GroupPolicyPreset { get; private set; } = new();
         public CaptchaSettings CaptchaSettings { get; set; } = new();
         public PasswordManagementSettings? PasswordManagement { get; set; }
-        public bool RequiresUserPrincipalName { get; private set; } 
+        public ExchangeActiveSyncDevicesManagement? ExchangeActiveSyncDevicesManagement { get; set; }
         public string? LoggingLevel { get; private set; }
         public string? LoggingFormat { get; private set; }
-        public bool EnableExchangeActiveSyncDevicesManagement { get; private set; }
         public string UICulture { get; private set; } = string.Empty;
         public string LdapBaseDn { get; private set; } = string.Empty;
 
-        [Obsolete("Use PasswordChangingManagementSettings.EnablePassword property instead")]
+        [Obsolete("Use ExchangeActiveSyncDevicesManagement.Enable instead")]
+        public bool EnableExchangeActiveSyncDevicesManagement { get; private set; }
+        [Obsolete("Use PasswordChangingManagementSettings.Enable property instead")]
         public bool EnablePasswordManagement { get; private set; }
         [Obsolete("Use PasswordChangingManagementSettings.ChangeValidPasswordMode property instead")]
         public ChangePasswordMode ChangeValidPasswordMode { get; private set; } =
@@ -32,6 +33,8 @@ namespace MultiFactor.SelfService.Linux.Portal.Settings
         public PasswordChangingSessionSettingsObsolete PasswordChangingSessionSettings { get; private set; } = new();
         [Obsolete("Use CaptchaSettings property instead")]
         public GoogleReCaptchaSettings GoogleReCaptchaSettings { get; private set; } = new();
+        [Obsolete("Use ActiveDirectorySettings.RequiresUserPrincipalName")]
+        public bool RequiresUserPrincipalName { get; private set; }
     }
 
     public enum ChangePasswordMode

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/Validating/PortalSettingsValidator.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/Validating/PortalSettingsValidator.cs
@@ -63,15 +63,15 @@ namespace MultiFactor.SelfService.Linux.Portal.Extensions
                     .NotNull().WithMessage(GetErrorMessage(portal => portal.PasswordManagement))
                     .ChildRules(portalValidation =>
                     {
-                        portalValidation.RuleFor(r => r!.PasswordChangingSession.CacheSize)
+                        portalValidation.RuleFor(r => r!.PasswordChangingSessionCacheSize)
                             .Must((model, value) => value is null ||
                                                  value >= Constants.BYTES_IN_MB && value < (100L * Constants.BYTES_IN_MB /* 100 MB */))
-                            .WithMessage($"Invalid password changing session cache size. Please check '{GetPropPath(x => x.PasswordManagement!.PasswordChangingSession.CacheSize)} property.'");
+                            .WithMessage($"Invalid password changing session cache size. Please check '{GetPropPath(x => x.PasswordManagement!.PasswordChangingSessionCacheSize)} property.'");
 
-                        portalValidation.RuleFor(r => r!.PasswordChangingSession.Lifetime)
+                        portalValidation.RuleFor(r => r!.PasswordChangingSessionLifetime)
                             .Must((model, value) => value is null ||
                                                     value.Value < TimeSpan.FromDays(10))
-                            .WithMessage($"Invalid password changing session lifetime. Please check '{GetPropPath(x => x.PasswordManagement!.PasswordChangingSession.Lifetime)} property.'");
+                            .WithMessage($"Invalid password changing session lifetime. Please check '{GetPropPath(x => x.PasswordManagement!.PasswordChangingSessionLifetime)} property.'");
                     });
                 
                 RuleFor(portal => portal)

--- a/src/MultiFactor.SelfService.Linux.Portal/Stories/RecoverPasswordStory/RecoverPasswordStory.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Stories/RecoverPasswordStory/RecoverPasswordStory.cs
@@ -34,7 +34,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Stories.RecoverPasswordStory
 
         public async Task<IActionResult> StartRecoverAsync(EnterIdentityForm form)
         {
-            if (_portalSettings.RequiresUserPrincipalName)
+            if (_portalSettings.ActiveDirectorySettings.RequiresUserPrincipalName)
             {
                 // AD requires UPN check
                 var userName = LdapIdentity.ParseUser(form.Identity);

--- a/src/MultiFactor.SelfService.Linux.Portal/Stories/SignInStory/SignInStory.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Stories/SignInStory/SignInStory.cs
@@ -45,7 +45,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Stories.SignInStory
         public async Task<IActionResult> ExecuteAsync(LoginViewModel model, SingleSignOnDto sso)
         {
             var userName = LdapIdentity.ParseUser(model.UserName);
-            if (_settings.RequiresUserPrincipalName)
+            if (_settings.ActiveDirectorySettings.RequiresUserPrincipalName)
             {
                 // AD requires UPN check      
                 if (userName.Type != IdentityType.UserPrincipalName)

--- a/src/MultiFactor.SelfService.Linux.Portal/Views/Account/Login.cshtml
+++ b/src/MultiFactor.SelfService.Linux.Portal/Views/Account/Login.cshtml
@@ -22,7 +22,7 @@
                 <p>@Localizer["Invitation"]</p>
                 <div class="form-row @(isCaptchaEnabled ? "mb-8" : "")">
                     <div class="input">
-                        @Html.TextBoxFor(m => m.UserName, new { placeholder = Settings.RequiresUserPrincipalName
+                        @Html.TextBoxFor(m => m.UserName, new { placeholder = Settings.ActiveDirectorySettings.RequiresUserPrincipalName
                             ? Localizer.GetString("UserNameUpn") 
                             : Localizer.GetString("UserName") })
                         @Html.ValidationMessageFor(m => m.UserName)

--- a/src/MultiFactor.SelfService.Linux.Portal/Views/ForgottenPassword/Change.cshtml
+++ b/src/MultiFactor.SelfService.Linux.Portal/Views/ForgottenPassword/Change.cshtml
@@ -15,7 +15,7 @@
                     <div class="input">
                         @Html.TextBoxFor(m => m.Identity, 
                             new { 
-                                placeholder = Settings.RequiresUserPrincipalName 
+                                placeholder = Settings.ActiveDirectorySettings.RequiresUserPrincipalName 
                                 ?  Localizer.GetString("UserNameUpn") 
                                 :  Localizer.GetString("UserName"),
                                 autocomplete = "off"

--- a/src/MultiFactor.SelfService.Linux.Portal/appsettings.production.xml
+++ b/src/MultiFactor.SelfService.Linux.Portal/appsettings.production.xml
@@ -24,7 +24,7 @@
 			<Password>password</Password>
 		</TechnicalAccountSettings>
 
-		<ActiveDirectorySettings>
+		<ActiveDirectorySettings requiresUserPrincipalName="false">
 			<!--<SecondFactorGroup>2FA Users</SecondFactorGroup>-->
 			<!--<UseUserPhone>true</UseUserPhone>-->
 			<!--<UseMobileUserPhone>true</UseMobileUserPhone>-->
@@ -37,35 +37,29 @@
 			<!--<ApiProxy>http://proxy:3128</ApiProxy>-->
 		</MultiFactorApiSettings>
 
-		<CaptchaSettings>
-			<Enabled>false</Enabled>
-			<!-- Google/Yandex-->
+		<CaptchaSettings enabled="false">
+			<!--Captcha provider: 'Google', 'Yandex'-->
 			<CaptchaType>Google</CaptchaType>
 			<Key>key</Key>
 			<Secret>secret</Secret>
-			<!--CaptchaRequired attribute describes pages where Captcha is displayed: Always/PasswordRecovery -->
+			<!--When Captcha is displayed: 'Always', 'PasswordRecovery' -->
 			<CaptchaRequired>Always</CaptchaRequired>
 		</CaptchaSettings>
-		<!--<RequiresUserPrincipalName>true</RequiresUserPrincipalName>-->
 
 		<!--<LoggingLevel>Info</LoggingLevel>-->
 		<!--<LoggingFormat>json</LoggingFormat>-->
 
 		<!-- Enable user password change. AD connection must be secure (SSL/TLS) -->
 		<!-- To Enable password recovery, Captcha on PasswordRecovery page must be enabled -->
-		<!--PasswordManagement enabled="false" allowPasswordRecovery="false"-->
+		<PasswordManagement enabled="false" allowPasswordRecovery="false">
+			<!-- Changing session duration in hh:mm:ss (00:02:00 by default) -->
+			<!-- <PasswordChangingSessionLifetime>00:02:00</PasswordChangingSessionLifetime> -->
+			<!-- Session storage size in `bytes` (5242880 by default, 1048576 is minimal value) -->
+			<!-- <PasswordChangingSessionCachesize>5242880</PasswordChangingSessionCachesize> -->
+		</PasswordManagement>
 
-			<!-- 
-				Expired Password Changing Session Settings
-				PasswordChangingSession attributes:
-					lifetime: Life time changing session in hh:mm:ss (00:02:00 by default)
-					cacheSize: Session storage size in `bytes` (5242880 by default, 1048576 is minimal value)
-			-->
-			<!-- PasswordChangingSession lifetime="00:02:00" cacheSize="1048576" /-->
-
-		<!--/PasswordManagement-->
-
-		<EnableExchangeActiveSyncDevicesManagement>false</EnableExchangeActiveSyncDevicesManagement>
+		<!-- Enable user Exchange AciveSync devices provisioning. Don't works with Samba. -->
+		<ExchangeActiveSyncDevicesManagement enabled="false" />
 
 		<!--<UICulture>auto:en</UICulture>-->
 

--- a/src/MultiFactor.SelfService.Linux.Portal/appsettings.xml
+++ b/src/MultiFactor.SelfService.Linux.Portal/appsettings.xml
@@ -30,8 +30,8 @@
 		   <Password>password</Password>
 		</TechnicalAccountSettings>
 
-
-		<ActiveDirectorySettings>
+		<!-- requiresUserPrincipalName: Only UPN user name format permitted -->
+		<ActiveDirectorySettings requiresUserPrincipalName="false">
 			<!--[Optional] Require second factor for users in specified group only (Single Sign-On users). Second-factor will be required for all users by default if setting is deleted. -->
 			<!--<SecondFactorGroup>2FA Users</SecondFactorGroup>-->
 
@@ -53,42 +53,34 @@
 			<!--<ApiProxy>http://proxy:3128</ApiProxy>-->
 		</MultiFactorApiSettings>
 		
-		<CaptchaSettings>
-			<Enabled>false</Enabled>
-			<!-- Google/Yandex-->
+		<CaptchaSettings enabled="false">
+			<!--Captcha provider: 'Google', 'Yandex'-->
 			<CaptchaType>Yandex</CaptchaType>
 			<Key>key</Key>
 			<Secret>secret</Secret>
-			<!--CaptchaRequired attribute describes pages where Captcha is displayed: Always/PasswordRecovery -->
+			<!--When Captcha is displayed: 'Always', 'PasswordRecovery' -->
 			<CaptchaRequired>Always</CaptchaRequired>
 		</CaptchaSettings>
 
 		<!-- Enable user password change. AD connection must be secure (SSL/TLS) -->
 		<!-- To Enable password recovery, Captcha on PasswordRecovery page must be enabled -->
 		<PasswordManagement enabled="false" allowPasswordRecovery="false">
-			
-			<!-- 
-				Expired Password Changing Session Settings
-				PasswordChangingSession attributes:
-					lifetime: Life time changing session in hh:mm:ss (00:02:00 by default)
-					cacheSize: Session storage size in `bytes` (5242880 by default, 1048576 is minimal value)
-			-->
-			<!-- PasswordChangingSession lifetime="00:02:00" cacheSize="1048576" /-->
-		
+			<!-- Changing session duration in hh:mm:ss (00:02:00 by default) -->
+			<!-- <PasswordChangingSessionLifetime>00:02:00</PasswordChangingSessionLifetime> -->
+			<!-- Session storage size in `bytes` (5242880 by default, 1048576 is minimal value) -->
+			<!-- <PasswordChangingSessionCachesize>5242880</PasswordChangingSessionCachesize> -->
 		</PasswordManagement>
 
-		<!-- Only UPN user name format permitted -->
-		<!--<RequiresUserPrincipalName>true</RequiresUserPrincipalName>-->
 		
 		<!-- Logging level: 'Debug', 'Info', 'Warn', 'Error' -->
 		<!--<LoggingLevel>Info</LoggingLevel>-->
 		<!--<LoggingFormat>json</LoggingFormat>-->
 
-		<!-- Enable user Exchange AciveSync devices provisioning. Not works with Samba. -->
-		<EnableExchangeActiveSyncDevicesManagement>false</EnableExchangeActiveSyncDevicesManagement>
+		<!-- Enable user Exchange AciveSync devices provisioning. Don't works with Samba. -->
+		<ExchangeActiveSyncDevicesManagement enabled="false" />
 
 		<!--
-			UI languahe selection:
+			UI language selection:
 			ru - Russian,
 			en - English,
 			auto:ru - check browser, default Russian,


### PR DESCRIPTION
- new ExchangeActiveSyncDevicesManagement section with Enabled field. EnableExchangeActiveSyncDevicesManagement field is obsolete now. 
- RequiresUserPrincipalName field was moved to ActiveDirectorySettings.  Root-placed RequiresUserPrincipalName is obsolete.
- PasswordChangingSession section was removed. It's child nodes moved to the PasswordManagement section.
- Cleaned configuration files and actualized the comments