### PR TITLE
LoadActiveDirectoryNestedGroups

### DIFF
--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/ProfileLoading/LdapProfileFilterProvider.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/ProfileLoading/LdapProfileFilterProvider.cs
@@ -15,7 +15,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.ProfileLoading
 
         public ILdapFilter GetProfileSearchFilter(LdapIdentity user)
         {
-            var searchFilter = LdapFilter.Create("objectClass", "user", "person");
+            var searchFilter = LdapFilter.Create("objectClass", "user", "person", "memberof");
             switch (_serverInfo.Implementation)
             {
                 case LdapImplementation.FreeIPA:

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/ProfileLoading/LdapProfileLoader.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/ProfileLoading/LdapProfileLoader.cs
@@ -77,13 +77,14 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.ProfileLoading
                 }
             }
 
-            if (attributes.TryGetValue(_memberOfAttr, out var memberOfAttr))
+            if (attributes.TryGetValue(_memberOfAttr, out var memberOfAttr) && !_portalSettings.LoadActiveDirectoryNestedGroup)
             {
                 var val = memberOfAttr.GetValues<string>().Select(entry => LdapIdentity.DnToCn(entry)).ToArray();
                 builder.AddAttribute(_memberOfAttr, val);
             }
             else
             {
+                _logger.LogDebug("LoadActiveDirectoryNestedGroups is true or memberof is empty. Loading groups...");
                 var allGroups = await GetAllUserGroups(domain, entry.Dn, connection);
                 var val = allGroups.Select(entry => LdapIdentity.DnToCn(entry.Dn)).ToArray();
                 builder.AddAttribute(_memberOfAttr, val);
@@ -98,6 +99,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.ProfileLoading
         {
             var escaped = GetDistinguishedNameEscaped(distinguishedName);
             var searchFilter = $"(member:1.2.840.113556.1.4.1941:={escaped})";
+            _logger.LogDebug($"GetAllUserGroups. {searchFilter}");
             return connection.SearchQueryAsync(domain.Name, searchFilter, LdapSearchScope.LDAP_SCOPE_SUB, "DistinguishedName");
         }
 

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/ProfileLoading/LdapProfileLoader.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/ProfileLoading/LdapProfileLoader.cs
@@ -77,7 +77,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.ProfileLoading
                 }
             }
 
-            if (attributes.TryGetValue(_memberOfAttr, out var memberOfAttr) && !_portalSettings.LoadActiveDirectoryNestedGroup)
+            if (attributes.TryGetValue(_memberOfAttr, out var memberOfAttr) && !_portalSettings.LoadActiveDirectoryNestedGroups)
             {
                 var val = memberOfAttr.GetValues<string>().Select(entry => LdapIdentity.DnToCn(entry)).ToArray();
                 builder.AddAttribute(_memberOfAttr, val);

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PortalSettings.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PortalSettings.cs
@@ -17,7 +17,7 @@
         public string LoggingFormat { get; private set; }
         public string UICulture { get; private set; } = string.Empty;
         public string LdapBaseDn { get; private set; } = string.Empty;
-        public bool LoadActiveDirectoryNestedGroup { get; private set; } = false;
+        public bool LoadActiveDirectoryNestedGroups { get; private set; } = false;
 
         [Obsolete("Use ExchangeActiveSyncDevicesManagement.Enable instead")]
         public bool EnableExchangeActiveSyncDevicesManagement { get; private set; }

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PortalSettings.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PortalSettings.cs
@@ -17,6 +17,7 @@
         public string LoggingFormat { get; private set; }
         public string UICulture { get; private set; } = string.Empty;
         public string LdapBaseDn { get; private set; } = string.Empty;
+        public bool LoadActiveDirectoryNestedGroup { get; private set; } = false;
 
         [Obsolete("Use ExchangeActiveSyncDevicesManagement.Enable instead")]
         public bool EnableExchangeActiveSyncDevicesManagement { get; private set; }

--- a/src/MultiFactor.SelfService.Linux.Portal/appsettings.production.xml
+++ b/src/MultiFactor.SelfService.Linux.Portal/appsettings.production.xml
@@ -62,7 +62,10 @@
 
         <!-- Enable user Exchange AciveSync devices provisioning. Doesn't work with Samba. -->
         <ExchangeActiveSyncDevicesManagement enabled="false" />
-
+        
+        <!-- Load Nested Groups during the profile loading -->
+        <!--LoadActiveDirectoryNestedGroups>false</LoadActiveDirectoryNestedGroups-->
+        
         <!--<UICulture>auto:en</UICulture>-->
 
         <!--<GroupPolicyPreset>-->

--- a/src/MultiFactor.SelfService.Linux.Portal/appsettings.xml
+++ b/src/MultiFactor.SelfService.Linux.Portal/appsettings.xml
@@ -79,7 +79,10 @@
 
         <!-- Enable user Exchange AciveSync devices provisioning. Doesn't work with Samba. -->
         <ExchangeActiveSyncDevicesManagement enabled="false" />
-
+        
+        <!-- Load Nested Groups while Profile loading -->
+        <!--LoadActiveDirectoryNestedGroups>false</LoadActiveDirectoryNestedGroups-->
+        
         <!--
 			UI language selection:
 			ru - Russian,

--- a/src/MultiFactor.SelfService.Linux.Portal/appsettings.xml
+++ b/src/MultiFactor.SelfService.Linux.Portal/appsettings.xml
@@ -80,7 +80,7 @@
         <!-- Enable user Exchange AciveSync devices provisioning. Doesn't work with Samba. -->
         <ExchangeActiveSyncDevicesManagement enabled="false" />
         
-        <!-- Load Nested Groups while Profile loading -->
+        <!-- Load Nested Groups during the profile loading -->
         <!--LoadActiveDirectoryNestedGroups>false</LoadActiveDirectoryNestedGroups-->
         
         <!--


### PR DESCRIPTION
### Release 02.09.2024 | Read nested LDAP groups in AD during profile loading
#### New
1. Added new config key `LoadActiveDirectoryNestedGroups` which makes the SSP to use the `member:1.2.840.113556.1.4.1941` AD filter to retrieve a user's groups.
#### Bugfixes
1. Fixed group retrieving during LDAP Profile loading.