### PR TITLE
DEV-566

### DIFF
--- a/src/MultiFactor.SelfService.Linux.Portal.Tests/LockAttributeChangerFactoryTests.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal.Tests/LockAttributeChangerFactoryTests.cs
@@ -1,0 +1,87 @@
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
+using MultiFactor.SelfService.Linux.Portal.Core.Authentication.AdditionalClaims.Description;
+using MultiFactor.SelfService.Linux.Portal.Core.LdapFilterBuilding;
+using MultiFactor.SelfService.Linux.Portal.Core.Metadata;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.ProfileLoading;
+using MultiFactor.SelfService.Linux.Portal.Settings;
+using MultiFactor.SelfService.Linux.Portal.Tests.Fixtures;
+
+namespace MultiFactor.SelfService.Linux.Portal.Tests;
+
+public class LockAttributeChangerFactoryTests
+{
+    [Theory]
+    [InlineData(LdapImplementation.OpenLdap)]
+    [InlineData(LdapImplementation.ActiveDirectory)]
+    [InlineData(LdapImplementation.FreeIPA)]
+    public void GetChanger_ShouldReturnRightChanger(LdapImplementation expectedLdapImplementation)
+    {
+        var portalSettings = new PortalSettings(
+            new CompanySettings(
+                "Name",
+                "Domain",
+                "logo",
+                string.Empty,
+                loadActiveDirectoryNestedGroups: false
+            ),
+            new ActiveDirectorySettings());
+        var filterProvider = SetupMockLdapProfileFilterProvider();
+        var builder = GetAppBuilder(portalSettings);
+        builder.Services.ReplaceService(filterProvider);
+        var app = builder.Build();
+        var attributeChangerMock = new Mock<IUserAttributeChanger>();
+        var loggerMock = new Mock<ILogger<ILockAttributeChanger>>();
+        var profileLoader = (LdapProfileLoader)app.Services.GetService<LdapProfileLoader>();
+        var connectionFactory = (LdapConnectionAdapterFactory)app.Services.GetService<LdapConnectionAdapterFactory>();;
+        var serverInfo = new LdapServerInfo(expectedLdapImplementation);
+        
+        var factory = new LockAttributeChangerFactory(serverInfo, attributeChangerMock.Object, connectionFactory, profileLoader, loggerMock.Object);
+        var changer = factory.CreateChanger();
+        
+        Assert.NotNull(changer);
+        Assert.NotNull(changer.AttributeName);
+        var typeName = changer.GetType().Name;
+        var actualLdapImplementation = GetChangerTypeByAttributeName(typeName);
+        Assert.Equal(expectedLdapImplementation, actualLdapImplementation);
+    }
+
+    private LdapImplementation GetChangerTypeByAttributeName(string typeName) => typeName switch
+    {
+        "AdLockAttributeChanger" => LdapImplementation.ActiveDirectory,
+        "OpenLdapLockAttributeChanger" => LdapImplementation.OpenLdap,
+        "IpaLockAttributeChanger" => LdapImplementation.FreeIPA,
+        _ => throw new ArgumentException($"Unknown type: {typeName}")
+    };
+    
+    private ILdapProfileFilterProvider SetupMockLdapProfileFilterProvider()
+    {
+        var filterProvider = new Mock<ILdapProfileFilterProvider>();
+        filterProvider
+            .Setup(x => x.GetProfileSearchFilter(It.IsAny<LdapIdentity>()))
+            .Returns(LdapFilter.Create("objectClass", "user", "person", "memberof"));
+        return filterProvider.Object;
+    }
+    
+    private WebApplicationBuilder GetAppBuilder(PortalSettings portalSettings)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services
+            .AddSingleton(portalSettings)
+            .AddSingleton<AdditionalClaimDescriptorsProvider>()
+            .AddSingleton<AdditionalClaimsMetadata>()
+            .AddSingleton<ILdapConnectionAdapter, LdapConnectionAdapter>()
+            .AddSingleton<ILdapProfileFilterProvider, LdapProfileFilterProvider>()
+            .AddSingleton<IBindIdentityFormatter, DefaultBindIdentityFormatter>()
+            .AddSingleton<LdapProfileLoader>()
+            .AddSingleton<LdapConnectionAdapterFactory>();
+        
+        return builder;
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Abstractions/Ldap/ILockAttributeChanger.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Abstractions/Ldap/ILockAttributeChanger.cs
@@ -3,5 +3,5 @@ namespace MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
 public interface ILockAttributeChanger
 {
     public string AttributeName { get; }
-    public Task<bool> ChangeLockAttributeValue(string userName, object value);
+    public Task<bool> ChangeLockAttributeValueAsync(string userName, object value);
 }

--- a/src/MultiFactor.SelfService.Linux.Portal/Abstractions/Ldap/ILockAttributeChanger.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Abstractions/Ldap/ILockAttributeChanger.cs
@@ -1,0 +1,7 @@
+namespace MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
+
+public interface ILockAttributeChanger
+{
+    public string AttributeName { get; }
+    public Task<bool> ChangeLockAttributeValue(string userName, object value);
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Abstractions/Ldap/IUserAttributeChanger.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Abstractions/Ldap/IUserAttributeChanger.cs
@@ -1,0 +1,9 @@
+using LdapForNet;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection;
+
+namespace MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
+
+public interface IUserAttributeChanger
+{
+    Task ChangeAttributeValueAsync(string dn, string attributeName, object attributeValue, ILdapConnectionAdapter connection);
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Authentication/TokenClaims.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Authentication/TokenClaims.cs
@@ -5,5 +5,6 @@
         string Identity, 
         bool MustChangePassword, 
         DateTime ValidTo,
-        bool MustResetPassword);
+        bool MustResetPassword,
+        bool MustUnlockUser = false);
 }

--- a/src/MultiFactor.SelfService.Linux.Portal/Authentication/TokenVerifier.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Authentication/TokenVerifier.cs
@@ -27,13 +27,14 @@ namespace MultiFactor.SelfService.Linux.Portal.Authentication
 
                 var identity = jwtSecurityToken.Subject;
                 var rawUserName = claimsPrincipal.Claims.SingleOrDefault(claim => claim.Type == Constants.MultiFactorClaims.RawUserName)?.Value;
-
+                var unlockUser = claimsPrincipal.Claims.FirstOrDefault(claim => claim.Type == Constants.MultiFactorClaims.UnlockUser)?.Value?.ToLower() == "true";
                 // use raw user name when possible couse multifactor may transform identity depend by settings
                 return new TokenClaims(jwtSecurityToken.Id,
                     !string.IsNullOrEmpty(rawUserName) ? rawUserName : identity,
                     claimsPrincipal.Claims.Any(claim => claim.Type == Constants.MultiFactorClaims.ChangePassword),
                     jwtSecurityToken.ValidTo,
-                    claimsPrincipal.Claims.Any(claim => claim.Type == Constants.MultiFactorClaims.ResetPassword));
+                    claimsPrincipal.Claims.Any(claim => claim.Type == Constants.MultiFactorClaims.ResetPassword),
+                    MustUnlockUser: unlockUser);
             }
             catch (Exception ex)
             {

--- a/src/MultiFactor.SelfService.Linux.Portal/Authentication/TokenVerifier.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Authentication/TokenVerifier.cs
@@ -25,15 +25,23 @@ namespace MultiFactor.SelfService.Linux.Portal.Authentication
                 var claimsPrincipal = handler.ValidateToken(accessToken, validationParameters, out var securityToken);
                 var jwtSecurityToken = (JwtSecurityToken)securityToken;
 
-                var identity = jwtSecurityToken.Subject;
-                var rawUserName = claimsPrincipal.Claims.SingleOrDefault(claim => claim.Type == Constants.MultiFactorClaims.RawUserName)?.Value;
-                var unlockUser = claimsPrincipal.Claims.FirstOrDefault(claim => claim.Type == Constants.MultiFactorClaims.UnlockUser)?.Value?.ToLower() == "true";
+                var rawUserName = claimsPrincipal.Claims
+                    .SingleOrDefault(claim => claim.Type == Constants.MultiFactorClaims.RawUserName)?.Value;
+                var identity = !string.IsNullOrEmpty(rawUserName) ? rawUserName : jwtSecurityToken.Subject;
+                var unlockUser = claimsPrincipal.Claims
+                                     .FirstOrDefault(claim => claim.Type == Constants.MultiFactorClaims.UnlockUser)
+                                     ?.Value?.ToLower() == "true";
+                var mustChangePassword =
+                    claimsPrincipal.Claims.Any(claim => claim.Type == Constants.MultiFactorClaims.ChangePassword);
+                var mustResetPassword =
+                    claimsPrincipal.Claims.Any(claim => claim.Type == Constants.MultiFactorClaims.ResetPassword);
                 // use raw user name when possible couse multifactor may transform identity depend by settings
-                return new TokenClaims(jwtSecurityToken.Id,
-                    !string.IsNullOrEmpty(rawUserName) ? rawUserName : identity,
-                    claimsPrincipal.Claims.Any(claim => claim.Type == Constants.MultiFactorClaims.ChangePassword),
-                    jwtSecurityToken.ValidTo,
-                    claimsPrincipal.Claims.Any(claim => claim.Type == Constants.MultiFactorClaims.ResetPassword),
+                return new TokenClaims(
+                    Id: jwtSecurityToken.Id,
+                    Identity: identity,
+                    MustChangePassword: mustChangePassword,
+                    ValidTo: jwtSecurityToken.ValidTo,
+                    MustResetPassword: mustResetPassword,
                     MustUnlockUser: unlockUser);
             }
             catch (Exception ex)

--- a/src/MultiFactor.SelfService.Linux.Portal/Controllers/ForgottenPasswordController.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Controllers/ForgottenPasswordController.cs
@@ -54,7 +54,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Controllers
             {
                 if (form.UnlockUser)
                 {
-                    return await _unlockUserStory.CallSecondFactor(form);
+                    return await _unlockUserStory.CallSecondFactorAsync(form);
                 }
 
                 return await _recoverPasswordStory.StartRecoverAsync(form);

--- a/src/MultiFactor.SelfService.Linux.Portal/Controllers/ForgottenPasswordController.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Controllers/ForgottenPasswordController.cs
@@ -5,6 +5,7 @@ using MultiFactor.SelfService.Linux.Portal.Authentication;
 using MultiFactor.SelfService.Linux.Portal.Core;
 using MultiFactor.SelfService.Linux.Portal.Exceptions;
 using MultiFactor.SelfService.Linux.Portal.Settings;
+using MultiFactor.SelfService.Linux.Portal.Stories;
 using MultiFactor.SelfService.Linux.Portal.Stories.RecoverPasswordStory;
 using MultiFactor.SelfService.Linux.Portal.Stories.SignInStory;
 using MultiFactor.SelfService.Linux.Portal.ViewModels;
@@ -16,6 +17,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Controllers
     {
         private readonly IStringLocalizer<SharedResource> _localizer;
         private readonly RecoverPasswordStory _recoverPasswordStory;
+        private readonly UnlockUserStory _unlockUserStory;
         private readonly TokenVerifier _tokenVerifier;
         private readonly DataProtection _dataProtection;
         private readonly ILogger _logger;
@@ -23,6 +25,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Controllers
         public ForgottenPasswordController(
             DataProtection dataProtection,
             RecoverPasswordStory recoverPasswordStory,
+            UnlockUserStory unlockUserStory,
             IStringLocalizer<SharedResource> localizer,
             TokenVerifier tokenVerifier,
             ILogger<ForgottenPasswordController> logger)
@@ -32,6 +35,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Controllers
             _localizer = localizer;
             _tokenVerifier = tokenVerifier;
             _dataProtection = dataProtection;
+            _unlockUserStory = unlockUserStory;
         }
 
         [HttpGet]
@@ -48,6 +52,11 @@ namespace MultiFactor.SelfService.Linux.Portal.Controllers
         {
             try
             {
+                if (form.UnlockUser)
+                {
+                    return await _unlockUserStory.CallSecondFactor(form);
+                }
+
                 return await _recoverPasswordStory.StartRecoverAsync(form);
             }
             catch (ModelStateErrorException ex)
@@ -77,7 +86,6 @@ namespace MultiFactor.SelfService.Linux.Portal.Controllers
                 HttpOnly = true
             });
 
-
             return View(new ResetPasswordForm
             {
                 Identity = token.Identity
@@ -92,7 +100,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Controllers
             {
                 return View("Reset", form);
             }
-           
+
             try
             {
                 var sessionCookie = Request.Cookies[Constants.PWD_RECOVERY_COOKIE];

--- a/src/MultiFactor.SelfService.Linux.Portal/Controllers/UnlockController.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Controllers/UnlockController.cs
@@ -13,7 +13,10 @@ public class UnlockController : ControllerBase
     private readonly UnlockUserStory _unlockUserStory;
     private readonly ILogger _logger;
 
-    public UnlockController(UnlockUserStory unlockUserStory, TokenVerifier tokenVerifier, ILogger<UnlockController> logger)
+    public UnlockController(
+        UnlockUserStory unlockUserStory,
+        TokenVerifier tokenVerifier,
+        ILogger<UnlockController> logger)
     {
         _logger = logger;
         _tokenVerifier = tokenVerifier;
@@ -31,7 +34,7 @@ public class UnlockController : ControllerBase
             return RedirectToAction("Wrong");
         }
 
-        if (!await _unlockUserStory.UnlockUser(token.Identity))
+        if (!await _unlockUserStory.UnlockUserAsync(token.Identity))
         {
             return RedirectToAction("Wrong");
         }

--- a/src/MultiFactor.SelfService.Linux.Portal/Controllers/UnlockController.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Controllers/UnlockController.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Localization;
+using MultiFactor.SelfService.Linux.Portal.Attributes;
+using MultiFactor.SelfService.Linux.Portal.Authentication;
+using MultiFactor.SelfService.Linux.Portal.Stories;
+
+namespace MultiFactor.SelfService.Linux.Portal.Controllers;
+
+[RequiredFeature(ApplicationFeature.PasswordRecovery)]
+public class UnlockController : ControllerBase
+{
+    private readonly TokenVerifier _tokenVerifier;
+    private readonly UnlockUserStory _unlockUserStory;
+    private readonly ILogger _logger;
+
+    public UnlockController(UnlockUserStory unlockUserStory, TokenVerifier tokenVerifier, ILogger<UnlockController> logger)
+    {
+        _logger = logger;
+        _tokenVerifier = tokenVerifier;
+        _unlockUserStory = unlockUserStory;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Complete(string accessToken)
+    {
+        var token = _tokenVerifier.Verify(accessToken);
+        if (!token.MustUnlockUser)
+        {
+            _logger.LogError("Invalid unlocking session for user '{identity:l}': required claims not found",
+                token.Identity);
+            return RedirectToAction("Wrong");
+        }
+
+        if (!await _unlockUserStory.UnlockUser(token.Identity))
+        {
+            return RedirectToAction("Wrong");
+        }
+
+        return RedirectToAction("Success");
+    }
+
+    public ActionResult Wrong()
+    {
+        return View();
+    }
+
+    public ActionResult Success()
+    {
+        return View();
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Core/Constants.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Core/Constants.cs
@@ -33,6 +33,7 @@
             public const string PasswordExpirationDate = "passwordExpirationDate";
             public const string ResetPassword = "resetPassword";
             public const string RawUserName = "rawUserName";
+            public const string UnlockUser = "unlockUser";
         }
 
         public static class HttpClients

--- a/src/MultiFactor.SelfService.Linux.Portal/Extensions/ConfigurationRegistering.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Extensions/ConfigurationRegistering.cs
@@ -58,7 +58,8 @@ namespace MultiFactor.SelfService.Linux.Portal.Extensions
                     PasswordChangingSessionLifetime =
                         settings.PasswordChangingSessionSettings?.PwdChangingSessionLifetime,
                     PasswordChangingSessionCacheSize =
-                        settings.PasswordChangingSessionSettings?.PwdChangingSessionCacheSize
+                        settings.PasswordChangingSessionSettings?.PwdChangingSessionCacheSize,
+                    AllowUserUnlock = settings.PasswordManagement?.AllowUserUnlock ?? false
                 };
             }
 

--- a/src/MultiFactor.SelfService.Linux.Portal/Extensions/ServicesConfiguring.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Extensions/ServicesConfiguring.cs
@@ -34,6 +34,8 @@ using System.Net;
 using MultiFactor.SelfService.Linux.Portal.Stories.RecoverPasswordStory;
 using MultiFactor.SelfService.Linux.Portal.Integrations.ActiveDirectory;
 using MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
+using MultiFactor.SelfService.Linux.Portal.Integrations;
+using MultiFactor.SelfService.Linux.Portal.Stories;
 
 namespace MultiFactor.SelfService.Linux.Portal.Extensions
 {
@@ -94,7 +96,12 @@ namespace MultiFactor.SelfService.Linux.Portal.Extensions
                 .AddTransient<ChangeExpiredPasswordStory>()
                 .AddTransient<ChangeValidPasswordStory>()
                 .AddTransient<SearchExchangeActiveSyncDevicesStory>()
-                .AddTransient<ChangeActiveSyncDeviceStateStory>();
+                .AddTransient<ChangeActiveSyncDeviceStateStory>()
+                
+                .AddSingleton<IUserAttributeChanger, UserAttributeChanger>()
+                .AddSingleton<LockAttributeChangerFactory>()
+                .AddSingleton(services => services.GetRequiredService<LockAttributeChangerFactory>().CreateChanger())
+                .AddTransient<UnlockUserStory>();
             
             ConfigureHttpClients(builder);
            

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/ActiveDirectory/AdLockAttributeChanger.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/ActiveDirectory/AdLockAttributeChanger.cs
@@ -27,8 +27,13 @@ public class AdLockAttributeChanger : ILockAttributeChanger
         _logger = logger;
     }
 
-    public async Task<bool> ChangeLockAttributeValue(string userName, object value)
+    public async Task<bool> ChangeLockAttributeValueAsync(string userName, object value)
     {
+        if (string.IsNullOrWhiteSpace(userName))
+        {
+            throw new ArgumentNullException(nameof(userName));
+        }
+
         try
         {
             var connectionAdapter = await _connectionFactory.CreateAdapterAsTechnicalAccAsync();
@@ -39,7 +44,7 @@ public class AdLockAttributeChanger : ILockAttributeChanger
                 AttributeName,
                 value,
                 connectionAdapter);
-            
+
             _logger.LogInformation("User '{username}' is unlocked", userName);
 
             return true;

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/ActiveDirectory/AdLockAttributeChanger.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/ActiveDirectory/AdLockAttributeChanger.cs
@@ -1,0 +1,60 @@
+using LdapForNet;
+using MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
+using MultiFactor.SelfService.Linux.Portal.Extensions;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.ProfileLoading;
+
+namespace MultiFactor.SelfService.Linux.Portal.Integrations.ActiveDirectory;
+
+public class AdLockAttributeChanger : ILockAttributeChanger
+{
+    private readonly IUserAttributeChanger _userAttributeChanger;
+    private readonly LdapConnectionAdapterFactory _connectionFactory;
+    private readonly LdapProfileLoader _profileLoader;
+    private readonly ILogger _logger;
+
+    public string AttributeName => "lockoutTime";
+
+    public AdLockAttributeChanger(
+        IUserAttributeChanger userAttributeChanger,
+        LdapConnectionAdapterFactory connectionAdapterFactory,
+        LdapProfileLoader profileLoader,
+        ILogger<ILockAttributeChanger> logger)
+    {
+        _userAttributeChanger = userAttributeChanger;
+        _connectionFactory = connectionAdapterFactory;
+        _profileLoader = profileLoader;
+        _logger = logger;
+    }
+
+    public async Task<bool> ChangeLockAttributeValue(string userName, object value)
+    {
+        try
+        {
+            var connectionAdapter = await _connectionFactory.CreateAdapterAsTechnicalAccAsync();
+
+            var profile = await _profileLoader.GetLdapProfile(connectionAdapter, userName);
+            await _userAttributeChanger.ChangeAttributeValueAsync(
+                profile.DistinguishedName,
+                AttributeName,
+                value,
+                connectionAdapter);
+            
+            _logger.LogInformation("User '{username}' is unlocked", userName);
+
+            return true;
+        }
+        catch (LdapUnwillingToPerformException ex)
+        {
+            _logger.LogWarning("Unlock operation for user '{username}' failed: {message:l}, {result:l}",
+                userName, ex.Message, ex.HResult);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Unlock operation for user '{username}' failed: {message:l}",
+                userName, ex.Message);
+            return false;
+        }
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/FreeIPA/IpaLockAttributeChanger.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/FreeIPA/IpaLockAttributeChanger.cs
@@ -27,8 +27,13 @@ public class IpaLockAttributeChanger : ILockAttributeChanger
         _logger = logger;
     }
     
-    public async Task<bool> ChangeLockAttributeValue(string userName, object value)
+    public async Task<bool> ChangeLockAttributeValueAsync(string userName, object value)
     {
+        if (string.IsNullOrWhiteSpace(userName))
+        {
+            throw new ArgumentNullException(nameof(userName));
+        }
+        
         try
         {
             var connectionAdapter = await _connectionFactory.CreateAdapterAsTechnicalAccAsync();

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/FreeIPA/IpaLockAttributeChanger.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/FreeIPA/IpaLockAttributeChanger.cs
@@ -1,0 +1,60 @@
+using LdapForNet;
+using MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
+using MultiFactor.SelfService.Linux.Portal.Extensions;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.ProfileLoading;
+
+namespace MultiFactor.SelfService.Linux.Portal.Integrations.FreeIPA;
+
+public class IpaLockAttributeChanger : ILockAttributeChanger
+{
+    private readonly IUserAttributeChanger _userAttributeChanger;
+    private readonly LdapConnectionAdapterFactory _connectionFactory;
+    private readonly LdapProfileLoader _profileLoader;
+    private readonly ILogger _logger;
+    
+    public string AttributeName => "pwdAccountLockedTime";
+    
+    public IpaLockAttributeChanger(
+        IUserAttributeChanger userAttributeChanger,
+        LdapConnectionAdapterFactory connectionAdapterFactory,
+        LdapProfileLoader profileLoader,
+        ILogger<ILockAttributeChanger> logger)
+    {
+        _userAttributeChanger = userAttributeChanger;
+        _connectionFactory = connectionAdapterFactory;
+        _profileLoader = profileLoader;
+        _logger = logger;
+    }
+    
+    public async Task<bool> ChangeLockAttributeValue(string userName, object value)
+    {
+        try
+        {
+            var connectionAdapter = await _connectionFactory.CreateAdapterAsTechnicalAccAsync();
+
+            var profile = await _profileLoader.GetLdapProfile(connectionAdapter, userName);
+            await _userAttributeChanger.ChangeAttributeValueAsync(
+                profile.DistinguishedName,
+                AttributeName,
+                value,
+                connectionAdapter);
+            
+            _logger.LogInformation("User '{username}' is unlocked", userName);
+
+            return true;
+        }
+        catch (LdapUnwillingToPerformException ex)
+        {
+            _logger.LogWarning("Unlock operation for user '{username}' failed: {message:l}, {result:l}",
+                userName, ex.Message, ex.HResult);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Unlock operation for user '{username}' failed: {message:l}",
+                userName, ex.Message);
+            return false;
+        }
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/LockAttributeChangerFactory.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/LockAttributeChangerFactory.cs
@@ -1,0 +1,62 @@
+using MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
+using MultiFactor.SelfService.Linux.Portal.Integrations.ActiveDirectory;
+using MultiFactor.SelfService.Linux.Portal.Integrations.FreeIPA;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.ProfileLoading;
+
+namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap;
+
+public class LockAttributeChangerFactory
+{
+    private readonly LdapServerInfo _serverInfo;
+    private readonly IUserAttributeChanger _userAttributeChanger;
+    private readonly LdapConnectionAdapterFactory _ldapConnectionAdapterFactory;
+    private readonly LdapProfileLoader _ldapProfileLoader;
+    private readonly ILogger<ILockAttributeChanger> _logger;
+
+    public LockAttributeChangerFactory(
+        LdapServerInfo serverInfo,
+        IUserAttributeChanger userAttributeChanger,
+        LdapConnectionAdapterFactory ldapConnectionAdapterFactory,
+        LdapProfileLoader ldapProfileLoader,
+        ILogger<ILockAttributeChanger> logger)
+    {
+        _serverInfo = serverInfo ?? throw new ArgumentNullException(nameof(serverInfo));
+        _userAttributeChanger = userAttributeChanger;
+        _ldapProfileLoader = ldapProfileLoader;
+        _ldapConnectionAdapterFactory = ldapConnectionAdapterFactory;
+        _logger = logger;
+    }
+
+    public ILockAttributeChanger CreateChanger()
+    {
+        switch (_serverInfo.Implementation)
+        {
+            case LdapImplementation.FreeIPA:
+                return new IpaLockAttributeChanger(
+                    _userAttributeChanger,
+                    _ldapConnectionAdapterFactory,
+                    _ldapProfileLoader,
+                    _logger);
+            case LdapImplementation.Samba:
+            case LdapImplementation.OpenLdap:
+                return new OpenLdapLockAttributeChanger(
+                    _userAttributeChanger,
+                    _ldapConnectionAdapterFactory,
+                    _ldapProfileLoader,
+                    _logger);
+            case LdapImplementation.ActiveDirectory:
+                return new AdLockAttributeChanger(
+                    _userAttributeChanger,
+                    _ldapConnectionAdapterFactory,
+                    _ldapProfileLoader,
+                    _logger);
+            default:
+                return new AdLockAttributeChanger(
+                    _userAttributeChanger,
+                    _ldapConnectionAdapterFactory,
+                    _ldapProfileLoader,
+                    _logger);
+        }
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/LockAttributeChangerFactory.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/LockAttributeChangerFactory.cs
@@ -3,6 +3,7 @@ using MultiFactor.SelfService.Linux.Portal.Integrations.ActiveDirectory;
 using MultiFactor.SelfService.Linux.Portal.Integrations.FreeIPA;
 using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection;
 using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.ProfileLoading;
+using MultiFactor.SelfService.Linux.Portal.Integrations.OpenLdap;
 
 namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap;
 
@@ -38,13 +39,13 @@ public class LockAttributeChangerFactory
                     _ldapConnectionAdapterFactory,
                     _ldapProfileLoader,
                     _logger);
-            case LdapImplementation.Samba:
             case LdapImplementation.OpenLdap:
                 return new OpenLdapLockAttributeChanger(
                     _userAttributeChanger,
                     _ldapConnectionAdapterFactory,
                     _ldapProfileLoader,
                     _logger);
+            case LdapImplementation.Samba:
             case LdapImplementation.ActiveDirectory:
                 return new AdLockAttributeChanger(
                     _userAttributeChanger,

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/OpenLdapLockAttributeChanger.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/OpenLdapLockAttributeChanger.cs
@@ -1,0 +1,60 @@
+using LdapForNet;
+using MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
+using MultiFactor.SelfService.Linux.Portal.Extensions;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.ProfileLoading;
+
+namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap;
+
+public class OpenLdapLockAttributeChanger : ILockAttributeChanger
+{
+    private readonly IUserAttributeChanger _userAttributeChanger;
+    private readonly LdapConnectionAdapterFactory _connectionFactory;
+    private readonly LdapProfileLoader _profileLoader;
+    private readonly ILogger _logger;
+    
+    public string AttributeName => "pwdLockoutDuration";
+    
+    public OpenLdapLockAttributeChanger(
+        IUserAttributeChanger userAttributeChanger,
+        LdapConnectionAdapterFactory connectionAdapterFactory,
+        LdapProfileLoader profileLoader,
+        ILogger<ILockAttributeChanger> logger)
+    {
+        _userAttributeChanger = userAttributeChanger;
+        _connectionFactory = connectionAdapterFactory;
+        _profileLoader = profileLoader;
+        _logger = logger;
+    }
+    
+    public async Task<bool> ChangeLockAttributeValue(string userName, object value)
+    {
+        try
+        {
+            var connectionAdapter = await _connectionFactory.CreateAdapterAsTechnicalAccAsync();
+
+            var profile = await _profileLoader.GetLdapProfile(connectionAdapter, userName);
+            await _userAttributeChanger.ChangeAttributeValueAsync(
+                profile.DistinguishedName,
+                AttributeName,
+                value,
+                connectionAdapter);
+            
+            _logger.LogInformation("User '{username}' is unlocked", userName);
+
+            return true;
+        }
+        catch (LdapUnwillingToPerformException ex)
+        {
+            _logger.LogWarning("Unlock operation for user '{username}' failed: {message:l}, {result:l}",
+                userName, ex.Message, ex.HResult);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Unlock operation for user '{username}' failed: {message:l}",
+                userName, ex.Message);
+            return false;
+        }
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/MultiFactorApi/Dto/UnlockUserDto.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/MultiFactorApi/Dto/UnlockUserDto.cs
@@ -1,0 +1,3 @@
+namespace MultiFactor.SelfService.Linux.Portal.Integrations.MultiFactorApi.Dto;
+
+public record UnlockUserDto(string Url);

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/MultiFactorApi/MultiFactorApi.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/MultiFactorApi/MultiFactorApi.cs
@@ -127,7 +127,24 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.MultiFactorApi
             };
 
             return ExecuteAsync(() => _clientAdapter.PostAsync<ApiResponse<ResetPasswordDto>>("self-service/start-reset-password", payload, GetBasicAuthHeaders()));
+        }
 
+        public Task<UnlockUserDto> StartUnlockingUser(string identity, string callbackUrl)
+        {
+            ArgumentNullException.ThrowIfNull(identity);
+            ArgumentNullException.ThrowIfNull(callbackUrl);
+            
+            var payload = new
+            {
+                Identity = identity,
+                CallbackUrl = callbackUrl,
+                Claims = new Dictionary<string, string>
+                {
+                    { MultiFactorClaims.UnlockUser, "true"}
+                }
+            };
+
+            return ExecuteAsync(() => _clientAdapter.PostAsync<ApiResponse<UnlockUserDto>>("self-service/start-unlock-user", payload, GetBasicAuthHeaders()));
         }
 
         private static async Task ExecuteAsync(Func<Task<ApiResponse>> method)

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/OpenLdap/OpenLdapLockAttributeChanger.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/OpenLdap/OpenLdapLockAttributeChanger.cs
@@ -4,7 +4,7 @@ using MultiFactor.SelfService.Linux.Portal.Extensions;
 using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection;
 using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.ProfileLoading;
 
-namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap;
+namespace MultiFactor.SelfService.Linux.Portal.Integrations.OpenLdap;
 
 public class OpenLdapLockAttributeChanger : ILockAttributeChanger
 {
@@ -27,8 +27,13 @@ public class OpenLdapLockAttributeChanger : ILockAttributeChanger
         _logger = logger;
     }
     
-    public async Task<bool> ChangeLockAttributeValue(string userName, object value)
+    public async Task<bool> ChangeLockAttributeValueAsync(string userName, object value)
     {
+        if (string.IsNullOrWhiteSpace(userName))
+        {
+            throw new ArgumentNullException(nameof(userName));
+        }
+        
         try
         {
             var connectionAdapter = await _connectionFactory.CreateAdapterAsTechnicalAccAsync();

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/UserAttributeChanger.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/UserAttributeChanger.cs
@@ -14,6 +14,13 @@ public class UserAttributeChanger : IUserAttributeChanger
         object attributeValue,
         ILdapConnectionAdapter connection)
     {
+        if (string.IsNullOrWhiteSpace(dn))
+            throw new ArgumentNullException(nameof(dn));
+        if (string.IsNullOrWhiteSpace(attributeName))
+            throw new ArgumentNullException(nameof(attributeName));
+        if (connection is null)
+            throw new ArgumentNullException(nameof(connection));
+
         var request = BuildModifyRequest(dn, attributeName, attributeValue);
         var response = await connection.SendRequestAsync(request);
 

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/UserAttributeChanger.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/UserAttributeChanger.cs
@@ -1,0 +1,45 @@
+using System.Text;
+using LdapForNet;
+using LdapForNet.Native;
+using MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection;
+
+namespace MultiFactor.SelfService.Linux.Portal.Integrations;
+
+public class UserAttributeChanger : IUserAttributeChanger
+{
+    public async Task ChangeAttributeValueAsync(
+        string dn,
+        string attributeName,
+        object attributeValue,
+        ILdapConnectionAdapter connection)
+    {
+        var request = BuildModifyRequest(dn, attributeName, attributeValue);
+        var response = await connection.SendRequestAsync(request);
+
+        if (response.ResultCode != Native.ResultCode.Success)
+        {
+            throw new Exception($"Failed to set attribute: {response.ResultCode}");
+        }
+    }
+
+    private ModifyRequest BuildModifyRequest(
+        string dn,
+        string attributeName,
+        object attributeValue)
+    {
+        var attrName = attributeName;
+
+        var attribute = new DirectoryModificationAttribute
+        {
+            Name = attrName,
+            LdapModOperation = Native.LdapModOperation.LDAP_MOD_REPLACE
+        };
+
+        var bytes = Encoding.UTF8.GetBytes(attributeValue?.ToString());
+
+        attribute.Add(bytes);
+
+        return new ModifyRequest(dn, attribute);
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/ForgottenPassword/Change.ru.resx
+++ b/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/ForgottenPassword/Change.ru.resx
@@ -159,4 +159,7 @@
   <data name="UserNameUpn" xml:space="preserve">
     <value>user@domain.loc</value>
   </data>
+  <data name="UnlockUser" xml:space="preserve">
+    <value>Разблокировать пользователя без смены пароля</value>
+  </data>
 </root>

--- a/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/Unlock/Success.en.resx
+++ b/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/Unlock/Success.en.resx
@@ -159,7 +159,7 @@
   <data name="UserNameUpn" xml:space="preserve">
     <value>user@domain.loc</value>
   </data>
-  <data name="UnlockUser" xml:space="preserve">
-    <value>Unlock user without changing password</value>
+  <data name="UnlockUserSuccess" xml:space="preserve">
+    <value>User successfully unlocked</value>
   </data>
 </root>

--- a/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/Unlock/Success.ru.resx
+++ b/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/Unlock/Success.ru.resx
@@ -118,48 +118,48 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CommonErrorTitle" xml:space="preserve">
-    <value>Reset Password Error</value>
+    <value>Ошибка сброса пароля</value>
   </data>
   <data name="EnterLogin" xml:space="preserve">
-    <value>Please enter name to continue password recovery</value>
+    <value>Введите имя пользователя, чтобы продолжить восстановление пароля</value>
   </data>
   <data name="ErrorMessage" xml:space="preserve">
-    <value>Contact Administrator for password recovery</value>
+    <value>Свяжитесь с Администратором для восстановления пароля</value>
   </data>
   <data name="Fail" xml:space="preserve">
-    <value>Failed to set new password</value>
+    <value>Не удалось установить новый пароль</value>
   </data>
   <data name="Info" xml:space="preserve">
-    <value>Please re-login with new password.</value>
+    <value>Пожалуйста, войдите заново с новым паролем.</value>
   </data>
   <data name="Invitation" xml:space="preserve">
-    <value>Please set new password. Kindly note, the new password:</value>
+    <value>Пожалуйста, установите новый пароль. Обратите внимание, новый пароль:</value>
   </data>
   <data name="Next" xml:space="preserve">
-    <value>Reset password</value>
+    <value>Сбросить пароль</value>
   </data>
   <data name="Ok" xml:space="preserve">
-    <value>Ok</value>
+    <value>Хорошо</value>
   </data>
   <data name="PleaseWait" xml:space="preserve">
-    <value>Please, wait...</value>
+    <value>Пожалуйста, подождите...</value>
   </data>
   <data name="Submit" xml:space="preserve">
-    <value>Confirm</value>
+    <value>Подтвердить</value>
   </data>
   <data name="Success" xml:space="preserve">
-    <value>New password successfully set</value>
+    <value>Новый пароль успешно установлен</value>
   </data>
   <data name="Title" xml:space="preserve">
-    <value>Password Recovery</value>
+    <value>Восстановление пароля</value>
   </data>
   <data name="UserName" xml:space="preserve">
-    <value>User Name</value>
+    <value>Имя пользователя</value>
   </data>
   <data name="UserNameUpn" xml:space="preserve">
     <value>user@domain.loc</value>
   </data>
-  <data name="UnlockUser" xml:space="preserve">
-    <value>Unlock user without changing password</value>
+  <data name="UnlockUserSuccess" xml:space="preserve">
+    <value>Пользователь успешно разблокирован</value>
   </data>
 </root>

--- a/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/Unlock/Success.ru.resx
+++ b/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/Unlock/Success.ru.resx
@@ -139,7 +139,7 @@
     <value>Сбросить пароль</value>
   </data>
   <data name="Ok" xml:space="preserve">
-    <value>Хорошо</value>
+    <value>Ок</value>
   </data>
   <data name="PleaseWait" xml:space="preserve">
     <value>Пожалуйста, подождите...</value>

--- a/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/Unlock/Wrong.en.resx
+++ b/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/Unlock/Wrong.en.resx
@@ -159,7 +159,7 @@
   <data name="UserNameUpn" xml:space="preserve">
     <value>user@domain.loc</value>
   </data>
-  <data name="UnlockUser" xml:space="preserve">
-    <value>Unlock user without changing password</value>
+  <data name="UnlockUserError" xml:space="preserve">
+    <value>User unlocking failed</value>
   </data>
 </root>

--- a/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/Unlock/Wrong.en.resx
+++ b/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/Unlock/Wrong.en.resx
@@ -138,9 +138,6 @@
   <data name="Next" xml:space="preserve">
     <value>Reset password</value>
   </data>
-  <data name="Ok" xml:space="preserve">
-    <value>Ok</value>
-  </data>
   <data name="PleaseWait" xml:space="preserve">
     <value>Please, wait...</value>
   </data>

--- a/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/Unlock/Wrong.ru.resx
+++ b/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/Unlock/Wrong.ru.resx
@@ -118,48 +118,48 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CommonErrorTitle" xml:space="preserve">
-    <value>Reset Password Error</value>
+    <value>Ошибка сброса пароля</value>
   </data>
   <data name="EnterLogin" xml:space="preserve">
-    <value>Please enter name to continue password recovery</value>
+    <value>Введите имя пользователя, чтобы продолжить восстановление пароля</value>
   </data>
   <data name="ErrorMessage" xml:space="preserve">
-    <value>Contact Administrator for password recovery</value>
+    <value>Свяжитесь с Администратором для восстановления пароля</value>
   </data>
   <data name="Fail" xml:space="preserve">
-    <value>Failed to set new password</value>
+    <value>Не удалось установить новый пароль</value>
   </data>
   <data name="Info" xml:space="preserve">
-    <value>Please re-login with new password.</value>
+    <value>Пожалуйста, войдите заново с новым паролем.</value>
   </data>
   <data name="Invitation" xml:space="preserve">
-    <value>Please set new password. Kindly note, the new password:</value>
+    <value>Пожалуйста, установите новый пароль. Обратите внимание, новый пароль:</value>
   </data>
   <data name="Next" xml:space="preserve">
-    <value>Reset password</value>
+    <value>Сбросить пароль</value>
   </data>
   <data name="Ok" xml:space="preserve">
-    <value>Ok</value>
+    <value>Хорошо</value>
   </data>
   <data name="PleaseWait" xml:space="preserve">
-    <value>Please, wait...</value>
+    <value>Пожалуйста, подождите...</value>
   </data>
   <data name="Submit" xml:space="preserve">
-    <value>Confirm</value>
+    <value>Подтвердить</value>
   </data>
   <data name="Success" xml:space="preserve">
-    <value>New password successfully set</value>
+    <value>Новый пароль успешно установлен</value>
   </data>
   <data name="Title" xml:space="preserve">
-    <value>Password Recovery</value>
+    <value>Восстановление пароля</value>
   </data>
   <data name="UserName" xml:space="preserve">
-    <value>User Name</value>
+    <value>Имя пользователя</value>
   </data>
   <data name="UserNameUpn" xml:space="preserve">
     <value>user@domain.loc</value>
   </data>
-  <data name="UnlockUser" xml:space="preserve">
-    <value>Unlock user without changing password</value>
+  <data name="UnlockUserError" xml:space="preserve">
+    <value>Не удалось разблокировать пользователя</value>
   </data>
 </root>

--- a/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/Unlock/Wrong.ru.resx
+++ b/src/MultiFactor.SelfService.Linux.Portal/Resources/Views/Unlock/Wrong.ru.resx
@@ -138,9 +138,6 @@
   <data name="Next" xml:space="preserve">
     <value>Сбросить пароль</value>
   </data>
-  <data name="Ok" xml:space="preserve">
-    <value>Хорошо</value>
-  </data>
   <data name="PleaseWait" xml:space="preserve">
     <value>Пожалуйста, подождите...</value>
   </data>

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordManagementSettings.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordManagementSettings.cs
@@ -10,6 +10,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Settings
             ChangePasswordMode.AsTechnicalAccount;
         public TimeSpan? PasswordChangingSessionLifetime { get; init; }
         public long? PasswordChangingSessionCacheSize { get; init; }
+        public bool AllowUserUnlock { get; init; }
     }
 
     [Obsolete]

--- a/src/MultiFactor.SelfService.Linux.Portal/Stories/UnlockUserStory.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Stories/UnlockUserStory.cs
@@ -1,0 +1,89 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Localization;
+using MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
+using MultiFactor.SelfService.Linux.Portal.Authentication;
+using MultiFactor.SelfService.Linux.Portal.Exceptions;
+using MultiFactor.SelfService.Linux.Portal.Extensions;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap;
+using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.CredentialVerification;
+using MultiFactor.SelfService.Linux.Portal.Integrations.MultiFactorApi;
+using MultiFactor.SelfService.Linux.Portal.Settings;
+using MultiFactor.SelfService.Linux.Portal.ViewModels;
+
+namespace MultiFactor.SelfService.Linux.Portal.Stories;
+
+public class UnlockUserStory
+{
+    private readonly ILockAttributeChanger _lockAttributeChanger;
+    private readonly TokenVerifier _tokenVerifier;
+    private readonly MultiFactorApi _apiClient;
+    private readonly PortalSettings _portalSettings;
+    private readonly IStringLocalizer<SharedResource> _localizer;
+    private readonly CredentialVerifier _credentialVerifier;
+    private readonly ILogger<UnlockUserStory> _logger;
+
+    public UnlockUserStory(
+        ILockAttributeChanger lockAttributeChanger,
+        TokenVerifier tokenVerifier,
+        MultiFactorApi apiClient,
+        PortalSettings portalSettings,
+        IStringLocalizer<SharedResource> localizer,
+        CredentialVerifier credentialVerifier,
+        ILogger<UnlockUserStory> logger)
+    {
+        _lockAttributeChanger = lockAttributeChanger;
+        _tokenVerifier = tokenVerifier;
+        _apiClient = apiClient;
+        _portalSettings = portalSettings;
+        _localizer = localizer;
+        _credentialVerifier = credentialVerifier;
+        _logger = logger;
+    }
+
+    public async Task<IActionResult> CallSecondFactor(EnterIdentityForm form)
+    {
+        if (!_portalSettings.PasswordManagement.AllowUserUnlock)
+            throw new InvalidOperationException();
+        
+        if (_portalSettings.ActiveDirectorySettings.RequiresUserPrincipalName)
+        {
+            // AD requires UPN check
+            var userName = LdapIdentity.ParseUser(form.Identity);
+            if (userName.Type != IdentityType.UserPrincipalName)
+            {
+                throw new ModelStateErrorException(_localizer.GetString("UserNameUpnRequired"));
+            }
+        }
+        
+        var identity = form.Identity.Trim();
+        if (_portalSettings.ActiveDirectorySettings.UseUpnAsIdentity)
+        {
+            var adValidationResult = await _credentialVerifier.VerifyMembership(identity);
+            identity = adValidationResult.UserPrincipalName;
+        }
+            
+        var callback = form.MyUrl.BuildRelativeUrl("Unlock/Complete", 2);
+        try
+        {
+            var response = await _apiClient.StartUnlockingUser(identity, callback);
+            return new RedirectResult(response.Url);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unable to recover password for user '{u:l}': {m:l}", form.Identity, ex.Message);
+            throw new ModelStateErrorException(_localizer.GetString("AD.UnableToChangePassword"));
+        }
+    }
+
+    public async Task<bool> UnlockUser(string identity)
+    {
+        if (!_portalSettings.PasswordManagement.AllowUserUnlock)
+            throw new InvalidOperationException();
+        
+        if (string.IsNullOrWhiteSpace(identity))
+            throw new ArgumentNullException(nameof(identity));
+
+        var result = await _lockAttributeChanger.ChangeLockAttributeValue(identity, 0);
+        return result;
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/ViewModels/EnterIdentityForm.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/ViewModels/EnterIdentityForm.cs
@@ -10,5 +10,10 @@ namespace MultiFactor.SelfService.Linux.Portal.ViewModels
         /// </summary>
         [HiddenInput]
         public string MyUrl { get; set; } = string.Empty;
+        
+        /// <summary>
+        /// Unlock user without password reset
+        /// </summary>
+        public bool UnlockUser { get; set; }
     }
 }

--- a/src/MultiFactor.SelfService.Linux.Portal/Views/ForgottenPassword/Change.cshtml
+++ b/src/MultiFactor.SelfService.Linux.Portal/Views/ForgottenPassword/Change.cshtml
@@ -30,10 +30,12 @@
 
                     @if (Settings.PasswordManagement.AllowUserUnlock)
                     {
-                        <div class="form-row">
-                            @Html.CheckBoxFor(x => x.UnlockUser)
-                            <label>@Localizer["UnlockUser"]</label>
-                        </div>
+                        <label class ="c-container">
+                            @Localizer["UnlockUser"]
+                         
+                            <input type="checkbox" asp-for="@Model.UnlockUser">
+                            <span class="c-checkmark"></span>
+                        </label>
                     }
 
                     @await Component.InvokeAsync("Captcha", new { Mode = CaptchaRequired.PasswordRecovery })

--- a/src/MultiFactor.SelfService.Linux.Portal/Views/ForgottenPassword/Change.cshtml
+++ b/src/MultiFactor.SelfService.Linux.Portal/Views/ForgottenPassword/Change.cshtml
@@ -17,8 +17,8 @@
                         @Html.TextBoxFor(m => m.Identity, 
                             new { 
                                 placeholder = Settings.ActiveDirectorySettings.RequiresUserPrincipalName 
-                                ?  Localizer.GetString("UserNameUpn") 
-                                :  Localizer.GetString("UserName"),
+                                    ?  Localizer.GetString("UserNameUpn") 
+                                    :  Localizer.GetString("UserName"),
                                 autocomplete = "off"
                             })
                         @Html.ValidationMessageFor(m => m.Identity)
@@ -27,8 +27,19 @@
                     @{
                         ViewBag.RenderCaptchaScripts = true;
                     }
+
+                    @if (Settings.PasswordManagement.AllowUserUnlock)
+                    {
+                        <div class="form-row">
+                            @Html.CheckBoxFor(x => x.UnlockUser)
+                            <label>@Localizer["UnlockUser"]</label>
+                        </div>
+                    }
+
                     @await Component.InvokeAsync("Captcha", new { Mode = CaptchaRequired.PasswordRecovery })
+
                 </div>
+
                 <div class="form-row">
                     <input type="hidden" name="myUrl" id="myUrl" />
                     <input disabled type="submit" class="btn-primary w-100" value="@Localizer["Submit"]" id="submit" />

--- a/src/MultiFactor.SelfService.Linux.Portal/Views/Unlock/Success.cshtml
+++ b/src/MultiFactor.SelfService.Linux.Portal/Views/Unlock/Success.cshtml
@@ -1,0 +1,15 @@
+﻿@model string
+@{
+    ViewBag.Title = @Localizer["Title"];
+}
+
+<div class="login">
+    <div class="form-column">
+        <hgroup>
+            <h2>@Localizer["UnlockUserSuccess"]</h2>
+        </hgroup>
+        <ul class="action">
+            <li><a href="~/" class="btn-primary w-100">@Localizer["Ok"]</a></li>
+        </ul>
+    </div>
+</div>

--- a/src/MultiFactor.SelfService.Linux.Portal/Views/Unlock/Success.cshtml
+++ b/src/MultiFactor.SelfService.Linux.Portal/Views/Unlock/Success.cshtml
@@ -5,11 +5,12 @@
 
 <div class="login">
     <div class="form-column">
-        <hgroup>
-            <h2>@Localizer["UnlockUserSuccess"]</h2>
-        </hgroup>
+        <h2>@Localizer["Title"]</h2>
+        <p>
+            @Localizer["UnlockUserSuccess"]
+        </p>
         <ul class="action">
-            <li><a href="~/" class="btn-primary w-100">@Localizer["Ok"]</a></li>
+            <li><a href="~/" class="center-button btn-primary w-100">@Localizer["Ok"]</a></li>
         </ul>
     </div>
 </div>

--- a/src/MultiFactor.SelfService.Linux.Portal/Views/Unlock/Wrong.cshtml
+++ b/src/MultiFactor.SelfService.Linux.Portal/Views/Unlock/Wrong.cshtml
@@ -5,11 +5,12 @@
 
 <div class="login">
     <div class="form-column">
-        <hgroup>
-            <h2>@Localizer["UnlockUserError"]</h2>
-        </hgroup>
-        <div class="action margin=10">
-                <a href="~/" class="btn-primary btn-lg">@Localizer["Ok"]</a>
-        </div>
+        <h2>@Localizer["Title"]</h2>
+        <p>
+            @Localizer["UnlockUserError"]
+        </p>
+        <ul class="action">
+            <li><a href="~/" class="center-button btn-primary w-100">@Localizer["Ok"]</a></li>
+        </ul>
     </div>
 </div>

--- a/src/MultiFactor.SelfService.Linux.Portal/Views/Unlock/Wrong.cshtml
+++ b/src/MultiFactor.SelfService.Linux.Portal/Views/Unlock/Wrong.cshtml
@@ -1,0 +1,15 @@
+﻿@model string
+@{
+    ViewBag.Title = @Localizer["Title"];
+}
+
+<div class="login">
+    <div class="form-column">
+        <hgroup>
+            <h2>@Localizer["UnlockUserError"]</h2>
+        </hgroup>
+        <div class="action margin=10">
+                <a href="~/" class="btn-primary btn-lg">@Localizer["Ok"]</a>
+        </div>
+    </div>
+</div>

--- a/src/MultiFactor.SelfService.Linux.Portal/wwwroot/css/site.css
+++ b/src/MultiFactor.SelfService.Linux.Portal/wwwroot/css/site.css
@@ -897,3 +897,77 @@ table.authenticators tr {
         transform: translateY(-50%);
     }
 }
+
+.c-container {
+    display: flex;
+    position: relative;
+    padding-left: 30px;
+    margin-bottom: 20px;
+    cursor: pointer;
+    font-size: 15px;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+    /* Hide the browser's default checkbox */
+.c-container input {
+        position: absolute;
+        opacity: 0;
+        cursor: pointer;
+        height: 0;
+        width: 0;
+}
+
+/* Create a custom checkbox */
+.c-checkmark {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 20px;
+    width: 20px;
+    border-radius: 5px;
+    border: 2px solid #CCE0F2;
+}
+
+/* On mouse-over, add a grey background color */
+.c-container:hover input ~ .c-checkmark {
+    /*    background-color: #ccc;*/
+}
+
+/* When the checkbox is checked, add a blue background */
+.c-container input:checked ~ .c-checkmark {
+    background-color: #579AD7;
+}
+
+/* Create the checkmark/indicator (hidden when not checked) */
+.c-checkmark:after {
+    content: "";
+    position: absolute;
+    display: none;
+}
+
+/* Show the checkmark when checked */
+.c-container input:checked ~ .c-checkmark:after {
+    display: block;
+}
+
+/* Style the checkmark/indicator */
+.c-container .c-checkmark:after {
+    left: 5px;
+    top: 0.01px;
+    width: 5px;
+    height: 13px;
+    border: solid white;
+    border-width: 0 2px 2px 0;
+    -webkit-transform: rotate(45deg);
+    -ms-transform: rotate(45deg);
+    transform: rotate(45deg);
+}
+
+.center-button {
+    justify-content:center;
+    display: flex;
+    align-items: center
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/wwwroot/css/site.css
+++ b/src/MultiFactor.SelfService.Linux.Portal/wwwroot/css/site.css
@@ -141,6 +141,7 @@ input {
         -webkit-box-sizing: border-box;
         box-sizing: border-box;
         padding: 0;
+        appearance: auto !important;
     }
 
     input[type=number]::-webkit-inner-spin-button,


### PR DESCRIPTION
### Release 29.04.2025 | Self-unlocking of the user

####  New

-   Added a self-unlocking function for the user. To do this, you need to enable `PasswordManagement` and add the `allowPasswordRecovery` and the `allowUserUnlock` settings. In this case, the user will be able to unlock his account himself after confirming the second factor. By default the function is disabled.
Examples
	```
	<PasswordManagement enabled="true" allowPasswordRecovery="true" allowUserUnlock="true">
	</PasswordManagement>
	```
	Or
	```
	<PasswordManagement enabled="true" allowPasswordRecovery="true">
		<AllowUserUnlock>true</AllowUserUnlock>
	</PasswordManagement>
	```