### PR TITLE
DEV-555 * добавлена секция конфига PasswordRequirements

### DIFF
--- a/src/MultiFactor.SelfService.Linux.Portal.Tests/Settings/PasswordRequirement/PasswordRequirementsServiceTests.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal.Tests/Settings/PasswordRequirement/PasswordRequirementsServiceTests.cs
@@ -1,0 +1,446 @@
+using MultiFactor.SelfService.Linux.Portal.Settings;
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement;
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Core;
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Rules;
+using Moq;
+using Microsoft.Extensions.Localization;
+using MultiFactor.SelfService.Linux.Portal.Resources;
+using System.Globalization;
+using MultiFactor.SelfService.Linux.Portal.Core;
+
+namespace MultiFactor.SelfService.Linux.Portal.Tests.Settings.PasswordRequirement
+{
+    public class PasswordRequirementsServiceTests
+    {
+        private readonly PasswordRequirementsService _service;
+        private readonly List<PasswordRequirementRule> _rules;
+        private readonly PasswordRequirementLocalizer _localizer;
+
+        public PasswordRequirementsServiceTests()
+        {
+            var mockStringLocalizer = new Mock<IStringLocalizer<PasswordRequirementResource>>();
+            
+            mockStringLocalizer.Setup(x => x[It.IsAny<string>()])
+                .Returns<string>(key => new LocalizedString(key, GetLocalizedValue(key)));
+
+            _localizer = new PasswordRequirementLocalizer(mockStringLocalizer.Object);
+
+            _rules = new List<PasswordRequirementRule>
+            {
+                CreateRule(Constants.PasswordRequirements.MIN_LENGTH),
+                CreateRule(Constants.PasswordRequirements.MAX_LENGTH),
+                CreateRule(Constants.PasswordRequirements.UPPER_CASE_LETTERS),
+                CreateRule(Constants.PasswordRequirements.LOWER_CASE_LETTERS),
+                CreateRule(Constants.PasswordRequirements.DIGITS),
+                CreateRule(Constants.PasswordRequirements.SPECIAL_SYMBOLS)
+            };
+
+            var settings = new PortalSettings
+            {
+                PasswordRequirements = new PasswordRequirementsSection
+                {
+                    PwdRequirement = new List<PasswordRequirementItem>()
+                }
+            };
+
+            _service = new PasswordRequirementsService(settings, _rules);
+        }
+
+        private string GetLocalizedValue(string key)
+        {
+            return key switch
+            {
+                Constants.PasswordRequirements.UPPER_CASE_LETTERS => "Password must contain at least one uppercase letter",
+                Constants.PasswordRequirements.LOWER_CASE_LETTERS => "Password must contain at least one lowercase letter",
+                Constants.PasswordRequirements.DIGITS => "Password must contain at least one digit",
+                Constants.PasswordRequirements.SPECIAL_SYMBOLS => "Password must contain at least one special symbol",
+                Constants.PasswordRequirements.MIN_LENGTH => "Password must be at least {0} characters long",
+                Constants.PasswordRequirements.MAX_LENGTH => "Password must not exceed {0} characters",
+                _ => key
+            };
+        }
+
+        private PasswordRequirementRule CreateRule(string condition, int? value = null, string descriptionEn = null, string descriptionRu = null)
+        {
+            return condition switch
+            {
+                Constants.PasswordRequirements.MIN_LENGTH => new MinLengthRule(value ?? 8, condition: condition, localizer: _localizer, descriptionEn: descriptionEn, descriptionRu: descriptionRu),
+                Constants.PasswordRequirements.MAX_LENGTH => new MaxLengthRule(value ?? 25, condition: condition, localizer: _localizer, descriptionEn: descriptionEn, descriptionRu: descriptionRu),
+                Constants.PasswordRequirements.UPPER_CASE_LETTERS => new UpperCaseLetterRule(condition: condition, localizer: _localizer, descriptionEn: descriptionEn, descriptionRu: descriptionRu),
+                Constants.PasswordRequirements.LOWER_CASE_LETTERS => new LowerCaseLetterRule(condition: condition, localizer: _localizer, descriptionEn: descriptionEn, descriptionRu: descriptionRu),
+                Constants.PasswordRequirements.DIGITS => new DigitRule(condition: condition, localizer: _localizer, descriptionEn: descriptionEn, descriptionRu: descriptionRu),
+                Constants.PasswordRequirements.SPECIAL_SYMBOLS => new SpecialSymbolRule(condition: condition, localizer: _localizer, descriptionEn: descriptionEn, descriptionRu: descriptionRu),
+                _ => throw new ArgumentException($"Unknown condition: {condition}")
+            };
+        }
+
+        [Fact]
+        public void ValidatePassword_NoRequirements_ReturnsValid()
+        {
+            // Arrange
+            var password = "any-password";
+
+            // Act
+            var result = _service.ValidatePassword(password);
+
+            // Assert
+            Assert.True(result.IsValid);
+            Assert.Null(result.ToString());
+        }
+
+        [Fact]
+        public void ValidatePassword_MinLengthRule_ValidatesCorrectly()
+        {
+            // Arrange
+            var settings = new PortalSettings
+            {
+                PasswordRequirements = new PasswordRequirementsSection
+                {
+                    PwdRequirement = new List<PasswordRequirementItem>
+                    {
+                        new PasswordRequirementItem
+                        {
+                            Enabled = true,
+                            Condition = Constants.PasswordRequirements.MIN_LENGTH,
+                            Value = "8"
+                        }
+                    }
+                }
+            };
+            var service = new PasswordRequirementsService(settings, _rules);
+
+            // Act & Assert
+            Assert.True(service.ValidatePassword("password123").IsValid);
+            Assert.False(service.ValidatePassword("pass").IsValid);
+        }
+
+        [Fact]
+        public void ValidatePassword_MaxLengthRule_ValidatesCorrectly()
+        {
+            // Arrange
+            var settings = new PortalSettings
+            {
+                PasswordRequirements = new PasswordRequirementsSection
+                {
+                    PwdRequirement = new List<PasswordRequirementItem>
+                    {
+                        new PasswordRequirementItem
+                        {
+                            Enabled = true,
+                            Condition = Constants.PasswordRequirements.MAX_LENGTH,
+                            Value = "10"
+                        }
+                    }
+                }
+            };
+            
+            var rules = new List<PasswordRequirementRule>
+            {
+                CreateRule(Constants.PasswordRequirements.MAX_LENGTH, 10)
+            };
+
+            var service = new PasswordRequirementsService(settings, rules);
+
+            // Act & Assert
+            Assert.True(service.ValidatePassword("password12").IsValid);
+            Assert.False(service.ValidatePassword("password123456").IsValid);
+        }
+
+        [Fact]
+        public void ValidatePassword_UpperCaseRule_ValidatesCorrectly()
+        {
+            // Arrange
+            var settings = new PortalSettings
+            {
+                PasswordRequirements = new PasswordRequirementsSection
+                {
+                    PwdRequirement = new List<PasswordRequirementItem>
+                    {
+                        new PasswordRequirementItem
+                        {
+                            Enabled = true,
+                            Condition = Constants.PasswordRequirements.UPPER_CASE_LETTERS
+                        }
+                    }
+                }
+            };
+            var service = new PasswordRequirementsService(settings, _rules);
+
+            // Act & Assert
+            Assert.True(service.ValidatePassword("Password123").IsValid);
+            Assert.False(service.ValidatePassword("password123").IsValid);
+        }
+
+        [Fact]
+        public void ValidatePassword_LowerCaseRule_ValidatesCorrectly()
+        {
+            // Arrange
+            var settings = new PortalSettings
+            {
+                PasswordRequirements = new PasswordRequirementsSection
+                {
+                    PwdRequirement = new List<PasswordRequirementItem>
+                    {
+                        new PasswordRequirementItem
+                        {
+                            Enabled = true,
+                            Condition = Constants.PasswordRequirements.LOWER_CASE_LETTERS
+                        }
+                    }
+                }
+            };
+            var service = new PasswordRequirementsService(settings, _rules);
+
+            // Act & Assert
+            Assert.True(service.ValidatePassword("Password123").IsValid);
+            Assert.False(service.ValidatePassword("PASSWORD123").IsValid);
+        }
+
+        [Fact]
+        public void ValidatePassword_DigitRule_ValidatesCorrectly()
+        {
+            // Arrange
+            var settings = new PortalSettings
+            {
+                PasswordRequirements = new PasswordRequirementsSection
+                {
+                    PwdRequirement = new List<PasswordRequirementItem>
+                    {
+                        new PasswordRequirementItem
+                        {
+                            Enabled = true,
+                            Condition = Constants.PasswordRequirements.DIGITS
+                        }
+                    }
+                }
+            };
+            var service = new PasswordRequirementsService(settings, _rules);
+
+            // Act & Assert
+            Assert.True(service.ValidatePassword("Password123").IsValid);
+            Assert.False(service.ValidatePassword("Password").IsValid);
+        }
+
+        [Fact]
+        public void ValidatePassword_SpecialSymbolRule_ValidatesCorrectly()
+        {
+            // Arrange
+            var settings = new PortalSettings
+            {
+                PasswordRequirements = new PasswordRequirementsSection
+                {
+                    PwdRequirement = new List<PasswordRequirementItem>
+                    {
+                        new PasswordRequirementItem
+                        {
+                            Enabled = true,
+                            Condition = Constants.PasswordRequirements.SPECIAL_SYMBOLS
+                        }
+                    }
+                }
+            };
+            var service = new PasswordRequirementsService(settings, _rules);
+
+            // Act & Assert
+            Assert.True(service.ValidatePassword("Password123!").IsValid);
+            Assert.False(service.ValidatePassword("Password123").IsValid);
+        }
+
+        [Fact]
+        public void ValidatePassword_MultipleRules_ValidatesCorrectly()
+        {
+            // Arrange
+            var settings = new PortalSettings
+            {
+                PasswordRequirements = new PasswordRequirementsSection
+                {
+                    PwdRequirement = new List<PasswordRequirementItem>
+                    {
+                        new PasswordRequirementItem
+                        {
+                            Enabled = true,
+                            Condition = Constants.PasswordRequirements.MIN_LENGTH,
+                            Value = "8"
+                        },
+                        new PasswordRequirementItem
+                        {
+                            Enabled = true,
+                            Condition = Constants.PasswordRequirements.UPPER_CASE_LETTERS
+                        },
+                        new PasswordRequirementItem
+                        {
+                            Enabled = true,
+                            Condition = Constants.PasswordRequirements.DIGITS
+                        }
+                    }
+                }
+            };
+            var service = new PasswordRequirementsService(settings, _rules);
+
+            // Act & Assert
+            Assert.True(service.ValidatePassword("Password123").IsValid);
+            Assert.False(service.ValidatePassword("pass").IsValid); // Too short
+            Assert.False(service.ValidatePassword("password123").IsValid); // No uppercase
+            Assert.False(service.ValidatePassword("Password").IsValid); // No digits
+        }
+
+        [Fact]
+        public void ValidatePassword_DisabledRules_AreIgnored()
+        {
+            // Arrange
+            var settings = new PortalSettings
+            {
+                PasswordRequirements = new PasswordRequirementsSection
+                {
+                    PwdRequirement = new List<PasswordRequirementItem>
+                    {
+                        new PasswordRequirementItem
+                        {
+                            Enabled = false,
+                            Condition = Constants.PasswordRequirements.MIN_LENGTH,
+                            Value = "8"
+                        },
+                        new PasswordRequirementItem
+                        {
+                            Enabled = true,
+                            Condition = Constants.PasswordRequirements.UPPER_CASE_LETTERS
+                        }
+                    }
+                }
+            };
+            var service = new PasswordRequirementsService(settings, _rules);
+
+            // Act & Assert
+            Assert.True(service.ValidatePassword("Pass").IsValid); // Short but has uppercase
+            Assert.False(service.ValidatePassword("pass").IsValid); // No uppercase
+        }
+
+        [Fact]
+        public void ValidatePassword_InvalidCondition_IsIgnored()
+        {
+            // Arrange
+            var settings = new PortalSettings
+            {
+                PasswordRequirements = new PasswordRequirementsSection
+                {
+                    PwdRequirement = new List<PasswordRequirementItem>
+                    {
+                        new PasswordRequirementItem
+                        {
+                            Enabled = true,
+                            Condition = "invalid-rule"
+                        },
+                        new PasswordRequirementItem
+                        {
+                            Enabled = true,
+                            Condition = Constants.PasswordRequirements.UPPER_CASE_LETTERS
+                        }
+                    }
+                }
+            };
+            var service = new PasswordRequirementsService(settings, _rules);
+
+            // Act & Assert
+            Assert.True(service.ValidatePassword("Pass").IsValid); // Valid because invalid rule is ignored
+            Assert.False(service.ValidatePassword("pass").IsValid); // Fails uppercase rule
+        }
+
+        [Fact]
+        public void GetRule_ReturnsCorrectRule()
+        {
+            // Act & Assert
+            Assert.NotNull(_service.GetRule(Constants.PasswordRequirements.MIN_LENGTH));
+            Assert.NotNull(_service.GetRule(Constants.PasswordRequirements.MAX_LENGTH));
+            Assert.NotNull(_service.GetRule(Constants.PasswordRequirements.UPPER_CASE_LETTERS));
+            Assert.NotNull(_service.GetRule(Constants.PasswordRequirements.LOWER_CASE_LETTERS));
+            Assert.NotNull(_service.GetRule(Constants.PasswordRequirements.DIGITS));
+            Assert.NotNull(_service.GetRule(Constants.PasswordRequirements.SPECIAL_SYMBOLS));
+            Assert.Null(_service.GetRule("invalid-rule"));
+        }
+
+        [Fact]
+        public void RuleLocalizedDescriptions_AreCorrectlySet()
+        {
+            // Arrange & Act
+            var minLengthRule = CreateRule(Constants.PasswordRequirements.MIN_LENGTH, 8,
+                "Password must be at least {0} characters long",
+                "Пароль должен содержать не менее {0} символов");
+            var maxLengthRule = CreateRule(Constants.PasswordRequirements.MAX_LENGTH, 25,
+                "Password must not exceed {0} characters",
+                "Пароль не должен превышать {0} символов");
+            var upperCaseRule = CreateRule(Constants.PasswordRequirements.UPPER_CASE_LETTERS,
+                descriptionEn: "Password must contain at least one uppercase letter",
+                descriptionRu: "Пароль должен содержать хотя бы одну заглавную букву");
+            var lowerCaseRule = CreateRule(Constants.PasswordRequirements.LOWER_CASE_LETTERS,
+                descriptionEn: "Password must contain at least one lowercase letter",
+                descriptionRu: "Пароль должен содержать хотя бы одну строчную букву");
+            var digitRule = CreateRule(Constants.PasswordRequirements.DIGITS,
+                descriptionEn: "Password must contain at least one digit",
+                descriptionRu: "Пароль должен содержать хотя бы одну цифру");
+            var specialSymbolRule = CreateRule(Constants.PasswordRequirements.SPECIAL_SYMBOLS,
+                descriptionEn: "Password must contain at least one special symbol",
+                descriptionRu: "Пароль должен содержать хотя бы один специальный символ");
+
+            // Assert English culture
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+            Assert.Equal(string.Format("Password must be at least {0} characters long", 8), minLengthRule.GetLocalizedDescription());
+            Assert.Equal(string.Format("Password must not exceed {0} characters", 25), maxLengthRule.GetLocalizedDescription());
+            Assert.Equal("Password must contain at least one uppercase letter", upperCaseRule.GetLocalizedDescription());
+            Assert.Equal("Password must contain at least one lowercase letter", lowerCaseRule.GetLocalizedDescription());
+            Assert.Equal("Password must contain at least one digit", digitRule.GetLocalizedDescription());
+            Assert.Equal("Password must contain at least one special symbol", specialSymbolRule.GetLocalizedDescription());
+
+            // Assert Russian culture
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("ru-RU");
+            Assert.Equal(string.Format("Пароль должен содержать не менее {0} символов", 8), minLengthRule.GetLocalizedDescription());
+            Assert.Equal(string.Format("Пароль не должен превышать {0} символов", 25), maxLengthRule.GetLocalizedDescription());
+            Assert.Equal("Пароль должен содержать хотя бы одну заглавную букву", upperCaseRule.GetLocalizedDescription());
+            Assert.Equal("Пароль должен содержать хотя бы одну строчную букву", lowerCaseRule.GetLocalizedDescription());
+            Assert.Equal("Пароль должен содержать хотя бы одну цифру", digitRule.GetLocalizedDescription());
+            Assert.Equal("Пароль должен содержать хотя бы один специальный символ", specialSymbolRule.GetLocalizedDescription());
+        }
+
+        [Fact]
+        public void RuleDescriptions_WithCustomValues_AreCorrectlyFormatted()
+        {
+            // Arrange & Act
+            var minLengthRule = CreateRule(Constants.PasswordRequirements.MIN_LENGTH, 12,
+                "Password must be at least 12 characters long",
+                "Пароль должен содержать не менее 12 символов");
+            var maxLengthRule = CreateRule(Constants.PasswordRequirements.MAX_LENGTH, 20,
+                "Password must not exceed 20 characters",
+                "Пароль не должен превышать 20 символов");
+
+            // Assert
+            Assert.Equal("Password must be at least 12 characters long", minLengthRule.DescriptionEn);
+            Assert.Equal("Password must not exceed 20 characters", maxLengthRule.DescriptionEn);
+            Assert.Equal("Пароль должен содержать не менее 12 символов", minLengthRule.DescriptionRu);
+            Assert.Equal("Пароль не должен превышать 20 символов", maxLengthRule.DescriptionRu);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("Qwerty")]
+        public void ValidatePassword_DefaultRequirements_ReturnsSuccess(string password)
+        {
+            // Arrange
+            var settings = new PortalSettings
+            {
+                PasswordRequirements = new PasswordRequirementsSection
+                {
+                    PwdRequirement = new List<PasswordRequirementItem>()
+                }
+            };
+            var service = new PasswordRequirementsService(settings, _rules);
+
+            // Act
+            var result = service.ValidatePassword(password);
+
+            // Assert
+            Assert.True(result.IsValid);
+            Assert.Null(result.ToString());
+        }
+    }
+} 

--- a/src/MultiFactor.SelfService.Linux.Portal.Tests/Settings/PasswordRequirement/PasswordRequirementsServiceTests.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal.Tests/Settings/PasswordRequirement/PasswordRequirementsServiceTests.cs
@@ -363,11 +363,11 @@ namespace MultiFactor.SelfService.Linux.Portal.Tests.Settings.PasswordRequiremen
         {
             // Arrange & Act
             var minLengthRule = CreateRule(Constants.PasswordRequirements.MIN_LENGTH, 8,
-                "Password must be at least {0} characters long",
+                "Password length should not be less than {0} characters long",
                 "Пароль должен содержать не менее {0} символов");
             var maxLengthRule = CreateRule(Constants.PasswordRequirements.MAX_LENGTH, 25,
-                "Password must not exceed {0} characters",
-                "Пароль не должен превышать {0} символов");
+                "Password length should not be greater than {0} characters",
+                "Пароль не должен быть длиннее {0} символов");
             var upperCaseRule = CreateRule(Constants.PasswordRequirements.UPPER_CASE_LETTERS,
                 descriptionEn: "Password must contain at least one uppercase letter",
                 descriptionRu: "Пароль должен содержать хотя бы одну заглавную букву");
@@ -383,8 +383,8 @@ namespace MultiFactor.SelfService.Linux.Portal.Tests.Settings.PasswordRequiremen
 
             // Assert English culture
             Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
-            Assert.Equal(string.Format("Password must be at least {0} characters long", 8), minLengthRule.GetLocalizedDescription());
-            Assert.Equal(string.Format("Password must not exceed {0} characters", 25), maxLengthRule.GetLocalizedDescription());
+            Assert.Equal(string.Format("Password length should not be less than {0} characters long", 8), minLengthRule.GetLocalizedDescription());
+            Assert.Equal(string.Format("Password length should not be greater than {0} characters", 25), maxLengthRule.GetLocalizedDescription());
             Assert.Equal("Password must contain at least one uppercase letter", upperCaseRule.GetLocalizedDescription());
             Assert.Equal("Password must contain at least one lowercase letter", lowerCaseRule.GetLocalizedDescription());
             Assert.Equal("Password must contain at least one digit", digitRule.GetLocalizedDescription());
@@ -393,7 +393,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Tests.Settings.PasswordRequiremen
             // Assert Russian culture
             Thread.CurrentThread.CurrentCulture = new CultureInfo("ru-RU");
             Assert.Equal(string.Format("Пароль должен содержать не менее {0} символов", 8), minLengthRule.GetLocalizedDescription());
-            Assert.Equal(string.Format("Пароль не должен превышать {0} символов", 25), maxLengthRule.GetLocalizedDescription());
+            Assert.Equal(string.Format("Пароль не должен быть длиннее {0} символов", 25), maxLengthRule.GetLocalizedDescription());
             Assert.Equal("Пароль должен содержать хотя бы одну заглавную букву", upperCaseRule.GetLocalizedDescription());
             Assert.Equal("Пароль должен содержать хотя бы одну строчную букву", lowerCaseRule.GetLocalizedDescription());
             Assert.Equal("Пароль должен содержать хотя бы одну цифру", digitRule.GetLocalizedDescription());

--- a/src/MultiFactor.SelfService.Linux.Portal/Core/Constants.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Core/Constants.cs
@@ -42,5 +42,28 @@
             public const string GoogleCaptcha = "googleCaptcha";
             public const string MultifactorIdpApi = "mfIdp";
         }
+        
+        public static class PasswordRequirements
+        {
+            public const string UPPER_CASE_LETTERS = "upper-case-letters";
+            public const string LOWER_CASE_LETTERS = "lower-case-letters";
+            public const string DIGITS = "digits";
+            public const string SPECIAL_SYMBOLS = "special-symbols";
+            public const string MIN_LENGTH = "min-length";
+            public const string MAX_LENGTH = "max-length";
+                
+            public static HashSet<string> GetAllKnownConstants()
+            {
+                return new HashSet<string>
+                {
+                    UPPER_CASE_LETTERS,
+                    LOWER_CASE_LETTERS,
+                    DIGITS,
+                    SPECIAL_SYMBOLS,
+                    MIN_LENGTH,
+                    MAX_LENGTH,
+                };
+            }
+        }
     }
 }

--- a/src/MultiFactor.SelfService.Linux.Portal/Core/ContentCache.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Core/ContentCache.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.AspNetCore.Localization;
+using MultiFactor.SelfService.Linux.Portal.Settings;
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement;
 using System.Text;
 
 namespace MultiFactor.SelfService.Linux.Portal.Core
@@ -14,8 +16,14 @@ namespace MultiFactor.SelfService.Linux.Portal.Core
         private static readonly string _directory = $"{Constants.WORKING_DIRECTORY}/Content";
         private readonly Lazy<Dictionary<string, string[]>> _loadedContent;
         private readonly IHttpContextAccessor _contextAccessor;
+        private readonly PortalSettings _portalSettings;
+        private readonly PasswordRequirementsService _passwordRequirementsService;
 
-        public ContentCache(IHttpContextAccessor contextAccessor, ILogger<ContentCache> logger)
+        public ContentCache(
+            IHttpContextAccessor contextAccessor, 
+            ILogger<ContentCache> logger,
+            PortalSettings portalSettings,
+            PasswordRequirementsService passwordRequirementsService)
         {
             _loadedContent = new Lazy<Dictionary<string, string[]>>(() =>
             {
@@ -56,15 +64,57 @@ namespace MultiFactor.SelfService.Linux.Portal.Core
                 return dict;
             });
             _contextAccessor = contextAccessor;
+            _portalSettings = portalSettings;
+            _passwordRequirementsService = passwordRequirementsService;
         }
 
         public string[] GetLines(ContentCategory category)
         {
+            if (category != ContentCategory.PasswordRequirements)
+            {
+                return Array.Empty<string>();
+            }
+
+            var requirements = new List<string>();
+
             var feature = _contextAccessor.HttpContext?.Features.Get<IRequestCultureFeature>();
             var culture = feature?.RequestCulture.Culture.TwoLetterISOLanguageName ?? "en";
+            
+            if (_portalSettings.PasswordRequirements?.PwdRequirement != null)
+            {
+                foreach (var requirement in _portalSettings.PasswordRequirements.PwdRequirement.Where(r => r.Enabled))
+                {
+                    string description = null;
 
-            var key = GetKey(category, culture);
-            return _loadedContent.Value.ContainsKey(key) ? _loadedContent.Value[key] : Array.Empty<string>();
+                    if (!string.IsNullOrEmpty(requirement.Condition))
+                    {
+                        var rule = _passwordRequirementsService.GetRule(requirement.Condition);
+                        if (rule != null)
+                        {
+                            description = rule.GetLocalizedDescription();
+                        }
+                    }
+
+                    if (string.IsNullOrEmpty(description))
+                    {
+                        description = culture == "ru" ? requirement.DescriptionRu : requirement.DescriptionEn;
+                    }
+
+                    if (!string.IsNullOrEmpty(description))
+                    {
+                        requirements.Add(description);
+                    }
+                }
+            }
+
+            // Если не нашли реков в конфиге, возвращаемся к чтению из файлов
+            if (requirements.Count == 0)
+            {
+                var key = GetKey(category, culture);
+                return _loadedContent.Value.ContainsKey(key) ? _loadedContent.Value[key] : Array.Empty<string>();
+            }
+
+            return requirements.ToArray();
         }
 
         private static string GetKey(ContentCategory category, string culture)

--- a/src/MultiFactor.SelfService.Linux.Portal/Extensions/ServicesConfiguring.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Extensions/ServicesConfiguring.cs
@@ -98,7 +98,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Extensions
                 .AddTransient<ChangeValidPasswordStory>()
                 .AddTransient<SearchExchangeActiveSyncDevicesStory>()
                 .AddTransient<ChangeActiveSyncDeviceStateStory>()
-                .ConfigurePasswordRequirements();
+                .AddPasswordRequirements()
                 .AddSingleton<IUserAttributeChanger, UserAttributeChanger>()
                 .AddSingleton<LockAttributeChangerFactory>()
                 .AddSingleton(services => services.GetRequiredService<LockAttributeChangerFactory>().CreateChanger())

--- a/src/MultiFactor.SelfService.Linux.Portal/Extensions/ServicesConfiguring.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Extensions/ServicesConfiguring.cs
@@ -34,6 +34,7 @@ using System.Net;
 using MultiFactor.SelfService.Linux.Portal.Stories.RecoverPasswordStory;
 using MultiFactor.SelfService.Linux.Portal.Integrations.ActiveDirectory;
 using MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement;
 
 namespace MultiFactor.SelfService.Linux.Portal.Extensions
 {
@@ -94,7 +95,8 @@ namespace MultiFactor.SelfService.Linux.Portal.Extensions
                 .AddTransient<ChangeExpiredPasswordStory>()
                 .AddTransient<ChangeValidPasswordStory>()
                 .AddTransient<SearchExchangeActiveSyncDevicesStory>()
-                .AddTransient<ChangeActiveSyncDeviceStateStory>();
+                .AddTransient<ChangeActiveSyncDeviceStateStory>()
+                .ConfigurePasswordRequirements();
             
             ConfigureHttpClients(builder);
            

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/PasswordChanging/ForgottenPasswordChanger.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/PasswordChanging/ForgottenPasswordChanger.cs
@@ -4,6 +4,7 @@ using MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
 using MultiFactor.SelfService.Linux.Portal.Extensions;
 using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection;
 using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.ProfileLoading;
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement;
 
 namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.PasswordChanging
 {
@@ -14,23 +15,32 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.PasswordChangin
         private readonly ILogger _logger;
         private readonly IStringLocalizer<SharedResource> _localizer;
         private readonly LdapProfileLoader _profileLoader;
+        private readonly PasswordRequirementsService _passwordRequirementsService;
 
 
         public ForgottenPasswordChanger(LdapConnectionAdapterFactory connectionFactory,
             ILogger<UserPasswordChanger> logger,
             IPasswordAttributeReplacer passwordAttributeReplacer,
             IStringLocalizer<SharedResource> localizer,
-            LdapProfileLoader profileLoader)
+            LdapProfileLoader profileLoader,
+            PasswordRequirementsService passwordRequirementsService)
         {
             _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
             _passwordAttributeReplacer = passwordAttributeReplacer ?? throw new ArgumentNullException(nameof(passwordAttributeReplacer));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _localizer = localizer ?? throw new ArgumentNullException(nameof(localizer));
             _profileLoader = profileLoader ?? throw new ArgumentNullException(nameof(profileLoader));
+            _passwordRequirementsService = passwordRequirementsService;
         }
 
         public async Task<PasswordChangingResult> ChangePassword(string username,string newPassword)
         {
+            var validationResult = _passwordRequirementsService.ValidatePassword(newPassword);
+            if (!validationResult.IsValid)
+            {
+                _logger.LogWarning("Change/reset password for user '{username}' failed: {message:l}", username, validationResult);
+                return new PasswordChangingResult(false, validationResult.ToString());
+            }
             try
             {
                 using var connection = await _connectionFactory.CreateAdapterAsTechnicalAccAsync();

--- a/src/MultiFactor.SelfService.Linux.Portal/Resources/PasswordRequirementResource.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Resources/PasswordRequirementResource.cs
@@ -1,0 +1,6 @@
+namespace MultiFactor.SelfService.Linux.Portal.Resources;
+
+public class PasswordRequirementResource
+{
+}
+

--- a/src/MultiFactor.SelfService.Linux.Portal/Resources/PasswordRequirementResource.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Resources/PasswordRequirementResource.cs
@@ -1,6 +1,8 @@
-namespace MultiFactor.SelfService.Linux.Portal.Resources;
-
-public class PasswordRequirementResource
+namespace MultiFactor.SelfService.Linux.Portal
 {
+    public class PasswordRequirementResource
+    {
+    }
 }
+
 

--- a/src/MultiFactor.SelfService.Linux.Portal/Resources/PasswordRequirementResource.en.resx
+++ b/src/MultiFactor.SelfService.Linux.Portal/Resources/PasswordRequirementResource.en.resx
@@ -1,0 +1,119 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+	<!-- 
+		Microsoft ResX Schema
+
+		Version 1.3
+
+		The primary goals of this format is to allow a simple XML format 
+		that is mostly human readable. The generation and parsing of the 
+		various data types are done through the TypeConverter classes 
+		associated with the data types.
+
+		Example:
+
+		... ado.net/XML headers & schema ...
+		<resheader name="resmimetype">text/microsoft-resx</resheader>
+		<resheader name="version">1.3</resheader>
+		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+		<data name="Name1">this is my long string</data>
+		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+			[base64 mime encoded serialized .NET Framework object]
+		</data>
+		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+			[base64 mime encoded string representing a byte array form of the .NET Framework object]
+		</data>
+
+		There are any number of "resheader" rows that contain simple 
+		name/value pairs.
+
+		Each data row contains a name, and value. The row also contains a 
+		type or mimetype. Type corresponds to a .NET class that support 
+		text/value conversion through the TypeConverter architecture. 
+		Classes that don't support this are serialized and stored with the 
+		mimetype set.
+
+		The mimetype is used for serialized objects, and tells the 
+		ResXResourceReader how to depersist the object. This is currently not 
+		extensible. For a given mimetype the value must be set accordingly:
+
+		Note - application/x-microsoft.net.object.binary.base64 is the format 
+		that the ResXResourceWriter will generate, however the reader can 
+		read any of the formats listed below.
+
+		mimetype: application/x-microsoft.net.object.binary.base64
+		value   : The object must be serialized with 
+			: System.Serialization.Formatters.Binary.BinaryFormatter
+			: and then encoded with base64 encoding.
+
+		mimetype: application/x-microsoft.net.object.soap.base64
+		value   : The object must be serialized with 
+			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+			: and then encoded with base64 encoding.
+
+		mimetype: application/x-microsoft.net.object.bytearray.base64
+		value   : The object must be serialized into a byte array 
+			: using a System.ComponentModel.TypeConverter
+			: and then encoded with base64 encoding.
+	-->
+	
+	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+		<xsd:element name="root" msdata:IsDataSet="true">
+			<xsd:complexType>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element name="data">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="resheader">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" />
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:complexType>
+		</xsd:element>
+	</xsd:schema>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<data name="upper-case-letters" xml:space="preserve">
+		<value>Password must contain at least one uppercase letter</value>
+	</data>
+	<data name="lower-case-letters" xml:space="preserve">
+		<value>Password must contain at least one lowercase letter</value>
+	</data>
+	<data name="digits" xml:space="preserve">
+		<value>Password must contain at least one digit</value>
+	</data>
+	<data name="special-symbols" xml:space="preserve">
+		<value>Password must contain at least one special symbol</value>
+	</data>
+	<data name="min-length" xml:space="preserve">
+		<value>Password must be at least {0} characters long</value>
+	</data>
+	<data name="max-length" xml:space="preserve">
+		<value>Password must not exceed {0} characters</value>
+	</data>
+</root>

--- a/src/MultiFactor.SelfService.Linux.Portal/Resources/PasswordRequirementResource.ru.resx
+++ b/src/MultiFactor.SelfService.Linux.Portal/Resources/PasswordRequirementResource.ru.resx
@@ -1,0 +1,119 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+	<!-- 
+		Microsoft ResX Schema
+
+		Version 1.3
+
+		The primary goals of this format is to allow a simple XML format 
+		that is mostly human readable. The generation and parsing of the 
+		various data types are done through the TypeConverter classes 
+		associated with the data types.
+
+		Example:
+
+		... ado.net/XML headers & schema ...
+		<resheader name="resmimetype">text/microsoft-resx</resheader>
+		<resheader name="version">1.3</resheader>
+		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+		<data name="Name1">this is my long string</data>
+		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+			[base64 mime encoded serialized .NET Framework object]
+		</data>
+		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+			[base64 mime encoded string representing a byte array form of the .NET Framework object]
+		</data>
+
+		There are any number of "resheader" rows that contain simple 
+		name/value pairs.
+
+		Each data row contains a name, and value. The row also contains a 
+		type or mimetype. Type corresponds to a .NET class that support 
+		text/value conversion through the TypeConverter architecture. 
+		Classes that don't support this are serialized and stored with the 
+		mimetype set.
+
+		The mimetype is used for serialized objects, and tells the 
+		ResXResourceReader how to depersist the object. This is currently not 
+		extensible. For a given mimetype the value must be set accordingly:
+
+		Note - application/x-microsoft.net.object.binary.base64 is the format 
+		that the ResXResourceWriter will generate, however the reader can 
+		read any of the formats listed below.
+
+		mimetype: application/x-microsoft.net.object.binary.base64
+		value   : The object must be serialized with 
+			: System.Serialization.Formatters.Binary.BinaryFormatter
+			: and then encoded with base64 encoding.
+
+		mimetype: application/x-microsoft.net.object.soap.base64
+		value   : The object must be serialized with 
+			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+			: and then encoded with base64 encoding.
+
+		mimetype: application/x-microsoft.net.object.bytearray.base64
+		value   : The object must be serialized into a byte array 
+			: using a System.ComponentModel.TypeConverter
+			: and then encoded with base64 encoding.
+	-->
+	
+	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+		<xsd:element name="root" msdata:IsDataSet="true">
+			<xsd:complexType>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element name="data">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="resheader">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" />
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:complexType>
+		</xsd:element>
+	</xsd:schema>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<data name="upper-case-letters" xml:space="preserve">
+		<value>Пароль должен содержать хотя бы одну заглавную букву</value>
+	</data>
+	<data name="lower-case-letters" xml:space="preserve">
+		<value>Пароль должен содержать хотя бы одну строчную букву</value>
+	</data>
+	<data name="digits" xml:space="preserve">
+		<value>Пароль должен содержать хотя бы одну цифру</value>
+	</data>
+	<data name="special-symbols" xml:space="preserve">
+		<value>Пароль должен содержать хотя бы один специальный символ</value>
+	</data>
+	<data name="min-length" xml:space="preserve">
+		<value>Пароль должен содержать не менее {0} символов</value>
+	</data>
+	<data name="max-length" xml:space="preserve">
+		<value>Пароль не должен превышать {0} символов</value>
+	</data>
+</root>

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/AddPasswordRequirementsExtension.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/AddPasswordRequirementsExtension.cs
@@ -6,7 +6,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement
 {
     public static class AddPasswordRequirementsExtension
     {
-        public static void ConfigurePasswordRequirements(this IServiceCollection services)
+        public static IServiceCollection AddPasswordRequirements(this IServiceCollection services)
         {
             services.AddSingleton<PasswordRequirementsService>();
             services.AddSingleton<PasswordRequirementLocalizer>();
@@ -58,6 +58,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement
                 }
                 return rules;
             });
+            return services;
         }
     }
 }

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/AddPasswordRequirementsExtension.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/AddPasswordRequirementsExtension.cs
@@ -1,0 +1,63 @@
+using MultiFactor.SelfService.Linux.Portal.Core;
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Core;
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Rules;
+
+namespace MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement
+{
+    public static class AddPasswordRequirementsExtension
+    {
+        public static void ConfigurePasswordRequirements(this IServiceCollection services)
+        {
+            services.AddSingleton<PasswordRequirementsService>();
+            services.AddSingleton<PasswordRequirementLocalizer>();
+
+            services.AddSingleton<IEnumerable<PasswordRequirementRule>>(sp =>
+            {
+                var settings = sp.GetRequiredService<PortalSettings>();
+                var rules = new List<PasswordRequirementRule>();
+                var requirements = settings.PasswordRequirements;
+                var localizer = sp.GetRequiredService<PasswordRequirementLocalizer>();
+                if (requirements != null)
+                {
+                    foreach (var req in requirements.PwdRequirement.Where(r => r.Enabled))
+                    {
+                        switch (req.Condition?.ToLowerInvariant())
+                        {
+                            case Constants.PasswordRequirements.UPPER_CASE_LETTERS:
+                                rules.Add(
+                                    new UpperCaseLetterRule(req.DescriptionEn, req.DescriptionRu, req.Condition, localizer));
+                                break;
+                            case Constants.PasswordRequirements.LOWER_CASE_LETTERS:
+                                rules.Add(
+                                    new LowerCaseLetterRule(req.DescriptionEn, req.DescriptionRu, req.Condition, localizer));
+                                break;
+                            case Constants.PasswordRequirements.DIGITS:
+                                rules.Add(
+                                    new DigitRule(req.DescriptionEn, req.DescriptionRu, req.Condition, localizer));
+                                break;
+                            case Constants.PasswordRequirements.SPECIAL_SYMBOLS:
+                                rules.Add(
+                                    new SpecialSymbolRule(req.DescriptionEn, req.DescriptionRu, req.Condition, localizer));
+                                break;
+                            case Constants.PasswordRequirements.MIN_LENGTH:
+                                if (int.TryParse(req.Value, out int minLength))
+                                {
+                                    rules.Add(
+                                        new MinLengthRule(minLength, req.DescriptionEn, req.DescriptionRu, req.Condition, localizer));
+                                }
+                                break;
+                            case Constants.PasswordRequirements.MAX_LENGTH:
+                                if (int.TryParse(req.Value, out int maxLength))
+                                {
+                                    rules.Add(
+                                        new MaxLengthRule(maxLength, req.DescriptionEn, req.DescriptionRu, req.Condition, localizer));
+                                }
+                                break;
+                        }
+                    }
+                }
+                return rules;
+            });
+        }
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Core/PasswordRequirementRule.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Core/PasswordRequirementRule.cs
@@ -1,0 +1,55 @@
+﻿namespace MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Core
+{
+    /// <summary>
+    /// Atomic password requirement rule.
+    /// </summary>
+    public abstract class PasswordRequirementRule
+    {
+        private readonly string _descriptionEn;
+        private readonly string _descriptionRu;
+        private readonly string _condition;
+        private readonly PasswordRequirementLocalizer _localizer;
+
+        protected PasswordRequirementRule(
+            string descriptionEn = null, 
+            string descriptionRu = null, 
+            string condition = null,
+            PasswordRequirementLocalizer localizer = null)
+        {
+            _descriptionEn = descriptionEn;
+            _descriptionRu = descriptionRu;
+            _condition = condition;
+            _localizer = localizer;
+        }
+
+        /// <summary>
+        /// Name of rule.
+        /// </summary>
+        public virtual string RuleName => _condition ?? GetType().Name;
+        
+        /// <summary>
+        /// Description in English
+        /// </summary>
+        public string DescriptionEn => _descriptionEn;
+        
+        /// <summary>
+        /// Description in Russian
+        /// </summary>
+        public string DescriptionRu => _descriptionRu;
+
+        /// <summary>
+        /// Returns localized description of the rule
+        /// </summary>
+        public virtual string GetLocalizedDescription()
+        {
+            return _localizer?.GetLocalizedDescription(this);
+        }
+
+        /// <summary>
+        /// Returns TRUE if the password and user are comply with the terms of the policy rule.
+        /// </summary>
+        /// <param name="rawPassword">Raw (not encoded) user password.</param>
+        /// <returns>True or False.</returns>
+        public abstract bool Validate(string rawPassword);
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Core/PasswordRequirementsSection.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Core/PasswordRequirementsSection.cs
@@ -1,0 +1,16 @@
+namespace MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Core
+{
+    public class PasswordRequirementsSection
+    {
+        public List<PasswordRequirementItem> PwdRequirement { get; set; }
+    }    
+    
+    public class PasswordRequirementItem
+    {
+        public bool Enabled { get; set; }
+        public string Condition { get; set; }
+        public string Value { get; set; }
+        public string DescriptionEn { get; set; }
+        public string DescriptionRu { get; set; }
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/PasswordRequirementLocalizer.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/PasswordRequirementLocalizer.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.Localization;
+using MultiFactor.SelfService.Linux.Portal.Resources;
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Core;
+using System.Globalization;
+
+namespace MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement;
+
+public class PasswordRequirementLocalizer(IStringLocalizer<PasswordRequirementResource> localizer)
+{
+    private readonly IStringLocalizer _localizer = localizer;
+
+    public string GetLocalizedDescription(PasswordRequirementRule rule)
+    {
+        var currentCulture = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
+        
+        var description = currentCulture == "ru" ? rule.DescriptionRu : rule.DescriptionEn;
+        
+        if (string.IsNullOrEmpty(description))
+        {
+            description = _localizer.GetString($"{rule.RuleName}");
+        }
+
+        return description;
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/PasswordRequirementLocalizer.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/PasswordRequirementLocalizer.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Localization;
-using MultiFactor.SelfService.Linux.Portal.Resources;
 using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Core;
 using System.Globalization;
 

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/PasswordRequirementsService.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/PasswordRequirementsService.cs
@@ -1,0 +1,44 @@
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Core;
+
+namespace MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement
+{
+    public class PasswordRequirementsService(PortalSettings portalSettings, IEnumerable<PasswordRequirementRule> rules)
+    {
+        public PasswordValidationResult ValidatePassword(string password)
+        {
+            if (portalSettings.PasswordRequirements?.PwdRequirement == null)
+            {
+                return new PasswordValidationResult();
+            }
+
+            foreach (var requirement in portalSettings.PasswordRequirements.PwdRequirement.Where(r => r.Enabled))
+            {
+                if (string.IsNullOrEmpty(requirement.Condition))
+                {
+                    continue;
+                }
+
+                var rule = GetRule(requirement.Condition);
+
+                if (rule == null)
+                {
+                    continue;
+                }
+
+                if (rule.Validate(password))
+                {
+                    continue;
+                }
+
+                return new PasswordValidationResult(rule.GetLocalizedDescription());
+            }
+
+            return new PasswordValidationResult();
+        }
+
+        public PasswordRequirementRule GetRule(string condition)
+        {
+            return rules.FirstOrDefault(r => string.Equals(r.RuleName, condition, StringComparison.InvariantCultureIgnoreCase));
+        }
+    }
+} 

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/PasswordValidationResult.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/PasswordValidationResult.cs
@@ -1,0 +1,12 @@
+namespace MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement;
+
+public class PasswordValidationResult(string errorMessage = null)
+{
+    public bool IsValid => string.IsNullOrEmpty(ErrorMessage);
+    private string ErrorMessage { get; } = errorMessage;
+
+    public override string ToString()
+    {
+        return ErrorMessage;
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Rules/DigitRule.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Rules/DigitRule.cs
@@ -1,0 +1,17 @@
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Core;
+
+namespace MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Rules
+{
+    public class DigitRule(
+        string descriptionEn = null,
+        string descriptionRu = null,
+        string condition = null,
+        PasswordRequirementLocalizer localizer = null)
+        : PasswordRequirementRule(descriptionEn, descriptionRu, condition, localizer)
+    {
+        public override bool Validate(string rawPassword)
+        {
+            return rawPassword?.Any(char.IsDigit) ?? false;
+        }
+    }
+} 

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Rules/LowerCaseLetterRule.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Rules/LowerCaseLetterRule.cs
@@ -1,0 +1,17 @@
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Core;
+
+namespace MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Rules
+{
+    public class LowerCaseLetterRule(
+        string descriptionEn = null, 
+        string descriptionRu = null, 
+        string condition = null,
+        PasswordRequirementLocalizer localizer = null)
+        : PasswordRequirementRule(descriptionEn, descriptionRu, condition, localizer)
+    {
+        public override bool Validate(string rawPassword)
+        {
+            return rawPassword?.Any(char.IsLower) ?? false;
+        }
+    }
+} 

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Rules/MaxLengthRule.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Rules/MaxLengthRule.cs
@@ -1,0 +1,24 @@
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Core;
+
+namespace MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Rules
+{
+    public class MaxLengthRule(
+        int maxLength,
+        string descriptionEn = null,
+        string descriptionRu = null,
+        string condition = null,
+        PasswordRequirementLocalizer localizer = null)
+        : PasswordRequirementRule(descriptionEn, descriptionRu, condition, localizer)
+    {
+        public override bool Validate(string rawPassword)
+        {
+            return rawPassword?.Length <= maxLength;
+        }
+
+        public override string GetLocalizedDescription()
+        {
+            var baseDescription = base.GetLocalizedDescription();
+            return string.Format(baseDescription, maxLength);
+        }
+    }
+} 

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Rules/MinLengthRule.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Rules/MinLengthRule.cs
@@ -1,0 +1,24 @@
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Core;
+
+namespace MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Rules
+{
+    public class MinLengthRule(
+        int minLength,
+        string descriptionEn = null,
+        string descriptionRu = null,
+        string condition = null,
+        PasswordRequirementLocalizer localizer = null)
+        : PasswordRequirementRule(descriptionEn, descriptionRu, condition, localizer)
+    {
+        public override bool Validate(string rawPassword)
+        {
+            return rawPassword?.Length >= minLength;
+        }
+
+        public override string GetLocalizedDescription()
+        {
+            var baseDescription = base.GetLocalizedDescription();
+            return string.Format(baseDescription, minLength);
+        }
+    }
+} 

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Rules/SpecialSymbolRule.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Rules/SpecialSymbolRule.cs
@@ -1,0 +1,17 @@
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Core;
+
+namespace MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Rules
+{
+    public class SpecialSymbolRule(
+        string descriptionEn = null, 
+        string descriptionRu = null, 
+        string condition = null,
+        PasswordRequirementLocalizer localizer = null)
+        : PasswordRequirementRule(descriptionEn, descriptionRu, condition, localizer)
+    {
+        public override bool Validate(string rawPassword)
+        {
+            return rawPassword?.Any(c => !char.IsLetterOrDigit(c) && !char.IsWhiteSpace(c)) ?? false;
+        }
+    }
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Rules/UpperCaseLetterRule.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PasswordRequirement/Rules/UpperCaseLetterRule.cs
@@ -1,0 +1,17 @@
+using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Core;
+
+namespace MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Rules
+{
+    public class UpperCaseLetterRule(
+        string descriptionEn = null, 
+        string descriptionRu = null, 
+        string condition = null,
+        PasswordRequirementLocalizer localizer = null)
+        : PasswordRequirementRule(descriptionEn, descriptionRu, condition, localizer)
+    {
+        public override bool Validate(string rawPassword)
+        {
+            return rawPassword?.Any(char.IsUpper) ?? false;
+        }
+    }
+} 

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/PortalSettings.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/PortalSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace MultiFactor.SelfService.Linux.Portal.Settings
+﻿using MultiFactor.SelfService.Linux.Portal.Settings.PasswordRequirement.Core;
+
+namespace MultiFactor.SelfService.Linux.Portal.Settings
 {
     public class PortalSettings
     {
@@ -13,6 +15,7 @@
         public CaptchaSettings CaptchaSettings { get; set; } = new();
         public PasswordManagementSettings PasswordManagement { get; set; }
         public ExchangeActiveSyncDevicesManagement ExchangeActiveSyncDevicesManagement { get; set; }
+        public PasswordRequirementsSection PasswordRequirements { get; init; } = new();
         public string LoggingLevel { get; private set; }
         public string LoggingFormat { get; private set; }
         public string UICulture { get; private set; } = string.Empty;

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/Validating/PortalSettingsValidator.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/Validating/PortalSettingsValidator.cs
@@ -92,6 +92,49 @@ namespace MultiFactor.SelfService.Linux.Portal.Extensions
                     .Must((model, value) => !model.PasswordManagement.AllowPasswordRecovery
                                           || model.PasswordManagement.AllowPasswordRecovery && model.PasswordManagement.Enabled)
                     .WithMessage($"Password management must be enabled before password recovery. Please, check '{GetPropPath(x => x.PasswordManagement.Enabled)}' property");
+                
+                
+                RuleFor(portal => portal.PasswordRequirements)
+                    .ChildRules(requirementsValidation =>
+                    {
+                        requirementsValidation.RuleForEach(r => r.PwdRequirement)
+                            .ChildRules(requirement =>
+                            {
+                                requirement.RuleFor(r => r.Enabled)
+                                    .NotNull().WithMessage("Enabled property must be specified for each password requirement");
+
+                                requirement.RuleFor(r => r.Condition)
+                                    .Must(condition => string.IsNullOrEmpty(condition) || Constants.PasswordRequirements.GetAllKnownConstants().Contains(condition))
+                                    .WithMessage("Invalid condition value. Must be one of: " + 
+                                        string.Join(", ", Constants.PasswordRequirements.GetAllKnownConstants()));
+
+                                requirement.RuleFor(r => r.Value)
+                                    .Must((model, value) => {
+                                        if (model.Condition == Constants.PasswordRequirements.MIN_LENGTH || 
+                                            model.Condition == Constants.PasswordRequirements.MAX_LENGTH)
+                                        {
+                                            return int.TryParse(value, out int length) && length > 0;
+                                        }
+                                        return true;
+                                    })
+                                    .WithMessage("Length value must be a positive number");
+                            });
+
+                        requirementsValidation.RuleFor(r => r.PwdRequirement)
+                            .Must(requirements => {
+                                var minLength = requirements.FirstOrDefault(x => x.Condition == Constants.PasswordRequirements.MIN_LENGTH);
+                                var maxLength = requirements.FirstOrDefault(x => x.Condition == Constants.PasswordRequirements.MAX_LENGTH);
+                                
+                                if (minLength != null && maxLength != null)
+                                {
+                                    return int.TryParse(minLength.Value, out int min) && 
+                                           int.TryParse(maxLength.Value, out int max) && 
+                                           min < max;
+                                }
+                                return true;
+                            })
+                            .WithMessage("Minimum length must be less than maximum length");
+                    });
             }
 
             private static string GetErrorMessage<TProperty>(Expression<Func<PortalSettings, TProperty>> propertySelector)

--- a/src/MultiFactor.SelfService.Linux.Portal/Settings/Validating/PortalSettingsValidator.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Settings/Validating/PortalSettingsValidator.cs
@@ -122,8 +122,8 @@ namespace MultiFactor.SelfService.Linux.Portal.Extensions
 
                         requirementsValidation.RuleFor(r => r.PwdRequirement)
                             .Must(requirements => {
-                                var minLength = requirements.FirstOrDefault(x => x.Condition == Constants.PasswordRequirements.MIN_LENGTH);
-                                var maxLength = requirements.FirstOrDefault(x => x.Condition == Constants.PasswordRequirements.MAX_LENGTH);
+                                var minLength = requirements?.FirstOrDefault(x => x.Condition == Constants.PasswordRequirements.MIN_LENGTH);
+                                var maxLength = requirements?.FirstOrDefault(x => x.Condition == Constants.PasswordRequirements.MAX_LENGTH);
                                 
                                 if (minLength != null && maxLength != null)
                                 {


### PR DESCRIPTION
* добавлена валидация новой секции
* добавлен сервис проверки пароля на стороне портала
* добавлена локализация требований к паролю
* добавлены тесты сервиса и локализации

## Структура конфигурации

```xml
<PasswordRequirements>
    <PwdRequirement enabled="true">
        <Condition>rule-name</Condition>
        <Value>optional-value</Value>
        <DescriptionEn>English description</DescriptionEn>
        <DescriptionRu>Описание на русском</DescriptionRu>
    </PwdRequirement>
</PasswordRequirements>
```

### Параметры элемента PwdRequirement

- `enabled` - включить/выключить правило (true/false) - **обязательный параметр**
- `Condition` - название правила проверки. Если указан, должен соответствовать одному из фиксированных значений:
  - `min-length` - минимальная длина
  - `max-length` - максимальная длина
  - `upper-case-letters` - заглавные буквы
  - `lower-case-letters` - строчные буквы
  - `digits` - цифры
  - `special-symbols` - специальные символы
- `Value` - опциональное значение для правил, требующих числового параметра
- `DescriptionEn` - описание правила на английском языке
- `DescriptionRu` - описание правила на русском языке

## Пример полной конфигурации

```xml
<PasswordRequirements>
    <PwdRequirement enabled="true">
        <Condition>min-length</Condition>
        <Value>10</Value>
        <DescriptionEn>Minimum length is 10 characters</DescriptionEn>
        <DescriptionRu>Минимальная длина 10 символов</DescriptionRu>
    </PwdRequirement>
    <PwdRequirement enabled="true">
        <Condition>max-length</Condition>
        <Value>25</Value>
        <DescriptionEn>Maximum length is 25 characters</DescriptionEn>
        <DescriptionRu>Максимальная длина 25 символов</DescriptionRu>
    </PwdRequirement>
    <PwdRequirement enabled="true">
        <Condition>upper-case-letters</Condition>
        <DescriptionEn>Must contain uppercase letters</DescriptionEn>
        <DescriptionRu>Должен содержать заглавные буквы</DescriptionRu>
    </PwdRequirement>
    <PwdRequirement enabled="true">
        <Condition>lower-case-letters</Condition>
        <DescriptionEn>Must contain lowercase letters</DescriptionEn>
        <DescriptionRu>Должен содержать строчные буквы</DescriptionRu>
    </PwdRequirement>
    <PwdRequirement enabled="true">
        <Condition>digits</Condition>
        <DescriptionEn>Must contain digits</DescriptionEn>
        <DescriptionRu>Должен содержать цифры</DescriptionRu>
    </PwdRequirement>
    <PwdRequirement enabled="true">
        <Condition>special-symbols</Condition>
        <DescriptionEn>Must contain special symbols</DescriptionEn>
        <DescriptionRu>Должен содержать специальные символы</DescriptionRu>
    </PwdRequirement>
    <PwdRequirement enabled="true">
        <DescriptionEn>Password must be unique and not used in the last 5 password changes</DescriptionEn>
        <DescriptionRu>Пароль должен быть уникальным и не использоваться в последних 5 сменах пароля</DescriptionRu>
    </PwdRequirement>
</PasswordRequirements>
``` 

Также можно добавить дополнительные информационные правила без проверки. Это правила без параметра `Condition`:

```xml
<PwdRequirement enabled="true">
    <DescriptionEn>Additional information about password requirements</DescriptionEn>
    <DescriptionRu>Дополнительная информация о требованиях к паролю</DescriptionRu>
</PwdRequirement>
```

## Приоритет применения
1. Система **сначала** проверяет наличие настроек в `appsettings.production.xml` в секции `<passwordRequirements>`.
2. Если в `appsettings.production.xml` есть **хотя бы одно** активное требование (`enabled="true"`), используются **только** настройки из `appsettings.production.xml`.
3. Если у требования с `Condition` не заполнен параметр `descriptionEn` (или `descriptionRu` для русского), то для этого требования будет использовано стандартное описание (вшитое в проект) на соответствующем языке.
4. Если в `appsettings.production.xml` требования **не указаны** или все `enabled="false"`, система использует требования из файла шаблона.
5. Если проверки на стороне портала были пройдены, то пароль отправляется на проверку в LDAP

## Важные замечания

1. Все правила с параметром `enabled="true"` будут отображаться на странице смены пароля (шаблон требований к паролю).
2. Правила с указанным `Condition` будут проверяться при создании/изменении пароля и отображены на форме.
3. Для правил `min-length` и `max-length` обязательно указывать числовое значение в параметре `Value`.
4. Минимальная длина должна быть меньше максимальной длины.
5. Если не указаны описания на русском или английском языке, система попытается использовать локализованные строки из ресурсов.
6. Значение параметра `Condition` должно точно соответствовать одному из предопределенных значений в системе