### PR TITLE
Feature/dev 656

### DIFF
--- a/src/MultiFactor.SelfService.Linux.Portal/Attributes/IsAuthorizedAttribute.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Attributes/IsAuthorizedAttribute.cs
@@ -27,7 +27,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Attributes
             if (cookie is null)
             {
                 var signOutStory = context.HttpContext.RequestServices.GetRequiredService<SignOutStory>();
-                signOutStory.Execute();
+                context.Result = signOutStory.Execute();
                 return;
             }
             var tokenClaims = tokenVerifier.Verify(cookie);

--- a/src/MultiFactor.SelfService.Linux.Portal/Controllers/AccountController.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Controllers/AccountController.cs
@@ -37,13 +37,14 @@ namespace MultiFactor.SelfService.Linux.Portal.Controllers
             var sso = _safeHttpContextAccessor.SafeGetSsoClaims();
             try
             {
+                var user = await loadProfile.ExecuteAsync();
+
                 if (sso.HasSamlSession())
                 {
-                    var user = await loadProfile.ExecuteAsync();
                     return new RedirectToActionResult("ByPassSamlSession", "Account", new { username = user.Identity, samlSession = sso.SamlSessionId });
                 }
 
-                return View(new LoginViewModel());
+                return RedirectToAction("Index", "Home");
             }
             catch (UnauthorizedException ex)
             {

--- a/src/MultiFactor.SelfService.Linux.Portal/Controllers/AccountController.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Controllers/AccountController.cs
@@ -171,6 +171,8 @@ namespace MultiFactor.SelfService.Linux.Portal.Controllers
         public async Task<IActionResult> ByPassSamlSession(string username, string samlSession,
             [FromServices] MultiFactorApi api)
         {
+            await api.AddToSsoMasterSession(samlSession);
+
             var page = await api.CreateSamlBypassRequestAsync(username, samlSession);
             return View(page);
         }

--- a/src/MultiFactor.SelfService.Linux.Portal/Controllers/HomeController.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Controllers/HomeController.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.Intrinsics.X86;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using MultiFactor.SelfService.Linux.Portal.Attributes;
 using MultiFactor.SelfService.Linux.Portal.Dto;
 using MultiFactor.SelfService.Linux.Portal.Stories.LoadProfileStory;

--- a/src/MultiFactor.SelfService.Linux.Portal/Controllers/HomeController.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Controllers/HomeController.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Reflection;
+using System.Runtime.Intrinsics.X86;
+using Microsoft.AspNetCore.Mvc;
 using MultiFactor.SelfService.Linux.Portal.Attributes;
 using MultiFactor.SelfService.Linux.Portal.Dto;
 using MultiFactor.SelfService.Linux.Portal.Stories.LoadProfileStory;
@@ -10,7 +12,13 @@ namespace MultiFactor.SelfService.Linux.Portal.Controllers
     {
         public async Task<IActionResult> Index(SingleSignOnDto claims, [FromServices] LoadProfileStory loadProfile)
         {
-            if (claims.HasSamlSession() || claims.HasOidcSession())
+            if (claims.HasSamlSession())
+            {
+                var user = await loadProfile.ExecuteAsync();
+                return new RedirectToActionResult("ByPassSamlSession", "Account", new { username = user.Identity, samlSession = claims.SamlSessionId });
+            }
+
+            if (claims.HasOidcSession())
             {
                 //re-login for saml or oidc authentication
                 return RedirectToAction("logout", "account", claims);

--- a/src/MultiFactor.SelfService.Linux.Portal/Extensions/SettingsConfiguring.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Extensions/SettingsConfiguring.cs
@@ -18,6 +18,11 @@ namespace MultiFactor.SelfService.Linux.Portal.Extensions
                 }
             });
 
+            if (applicationBuilder.Environment.EnvironmentName == "localhost")
+            {
+                applicationBuilder.Configuration.AddUserSecrets<Program>();
+            }
+
             return applicationBuilder;
         }
     }

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/MultiFactorApi/Dto/SsoMasterSessionDto.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/MultiFactorApi/Dto/SsoMasterSessionDto.cs
@@ -1,0 +1,7 @@
+﻿namespace MultiFactor.SelfService.Linux.Portal.Integrations.MultiFactorApi.Dto
+{
+    public record SsoMasterSessionDto(
+        string MasterSessionId,
+        List<string> SamlSessionIds
+        );
+}

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/MultiFactorApi/MultiFactorApi.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/MultiFactorApi/MultiFactorApi.cs
@@ -69,6 +69,35 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.MultiFactorApi
         }
 
         /// <summary>
+        /// Returns SSO master session.
+        /// </summary>
+        /// <param name="userIdentity"></param>
+        public async Task<SsoMasterSessionDto> GetSsoMasterSession()
+        {
+            var response = await ExecuteAsync(() => _clientAdapter.GetAsync<ApiResponse<SsoMasterSessionDto>>("self-service/get-master-session", GetBearerAuthHeaders()));
+            return new SsoMasterSessionDto(response.MasterSessionId, response.SamlSessionIds);
+        }
+
+        /// <summary>
+        /// Adds SAML session to SSO master session.
+        /// </summary>
+        /// <param name="userIdentity"></param>
+        public async Task<SsoMasterSessionDto> AddToSsoMasterSession(string samlSessionId)
+        {
+            var payload = new
+            {
+                SamlSessionId = samlSessionId
+            };
+
+            var response = await ExecuteAsync(() => _clientAdapter.PostAsync<ApiResponse<SsoMasterSessionDto>>(
+                "self-service/add-to-master-session", 
+                payload, 
+                GetBearerAuthHeaders()));
+
+            return new SsoMasterSessionDto(response.MasterSessionId, response.SamlSessionIds);
+        }
+
+        /// <summary>
         /// Returns new access token.
         /// </summary>
         /// <param name="username"></param>

--- a/src/MultiFactor.SelfService.Linux.Portal/Stories/SignOutStory/SignOutStory.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Stories/SignOutStory/SignOutStory.cs
@@ -2,6 +2,7 @@
 using MultiFactor.SelfService.Linux.Portal.Core;
 using MultiFactor.SelfService.Linux.Portal.Core.Http;
 using MultiFactor.SelfService.Linux.Portal.Extensions;
+using MultiFactor.SelfService.Linux.Portal.ModelBinding.Binders;
 using System.Text;
 
 namespace MultiFactor.SelfService.Linux.Portal.Stories.SignOutStory
@@ -24,7 +25,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Stories.SignOutStory
             _contextAccessor.HttpContext.Request.Headers.Remove("Authorization");
 
             var redirectUrl = new StringBuilder("/account/login");
-            var claimsDto = _contextAccessor.SafeGetSsoClaims();
+            var claimsDto = MultiFactorClaimsDtoBinder.FromRequest(_contextAccessor.HttpContext.Request);
             if (claimsDto.HasSamlSession())
             {
                 redirectUrl.Append($"?{Constants.MultiFactorClaims.SamlSessionId}={claimsDto.SamlSessionId}");


### PR DESCRIPTION
* Добавлено использование уже существующей сессии для аутентификации в других приложениях
* Исправлено поведение /account/login для авторизованных пользователей

### Полный список правок

- IsAuthorizedAttribute.cs
  - Исправлено перенаправление на страницу авторизации для не авторизованных пользователей.

- AccountController.cs
  - /account/login больше не запрашивает повторной авторизации для уже авторизованных пользователей.
  - /account/login при наличии SAML сессии делает bypass.

- HomeController.cs
  - Добавлен bypass для SAML сессий.

- SignOutStory.cs
  - Исправлено получение SingleSignOnDto. Не всегда SignOutStory вызывается после [ConsumeSsoClaims], при некоторых сценариях мы теряли SingleSignOnDto.

- SettingsConfiguring.cs
  - Добавлено использование secrets.json