### PR TITLE
DEV-836: added profiling for LdapConnectionAdapter and cache for Wher…

### DIFF
--- a/src/MultiFactor.SelfService.Linux.Portal/Extensions/ServicesConfiguring.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Extensions/ServicesConfiguring.cs
@@ -47,6 +47,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Extensions
         {
             builder.Services
                 .AddSession()
+                .AddMemoryCache()
                 .AddHttpContextAccessor()
                 .AddPasswordChangingSessionCache()
                 .AddSingleton<ILdapConnectionAdapter, LdapConnectionAdapter>()

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/ActiveDirectory/ExchangeActiveSync/ExchangeActiveSyncDeviceStateChanger.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/ActiveDirectory/ExchangeActiveSync/ExchangeActiveSyncDeviceStateChanger.cs
@@ -6,6 +6,7 @@ using FluentValidation;
 using MultiFactor.SelfService.Linux.Portal.Settings;
 using MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
 using MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace MultiFactor.SelfService.Linux.Portal.Integrations.ActiveDirectory.ExchangeActiveSync
 {
@@ -15,17 +16,20 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.ActiveDirectory.Exch
         private readonly ILogger<ExchangeActiveSyncDeviceStateChanger> _logger;
         private readonly IBindIdentityFormatter _bindDnFormatter;
         private readonly ILdapConnectionAdapter _ldapConnectionAdapter;
+        private readonly IMemoryCache _memoryCache;
         
         public ExchangeActiveSyncDeviceStateChanger(
             PortalSettings settings,
             ILogger<ExchangeActiveSyncDeviceStateChanger> logger,
             IBindIdentityFormatter bindDnFormatter,
-            ILdapConnectionAdapter ldapConnectionAdapter)
+            ILdapConnectionAdapter ldapConnectionAdapter,
+            IMemoryCache memoryCache)
         {
             _settings = settings;
             _logger = logger;
             _bindDnFormatter = bindDnFormatter;
             _ldapConnectionAdapter = ldapConnectionAdapter;
+            _memoryCache = memoryCache;
         }
 
         public async Task ChangeStateAsync(ExchangeActiveSyncDeviceInfo device, ExchangeActiveSyncDeviceAccessState state)
@@ -40,6 +44,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.ActiveDirectory.Exch
                     _settings.CompanySettings.Domain,
                     techUser, 
                     _settings.TechnicalAccountSettings.Password!, 
+                    _memoryCache,
                     config => config.SetBindIdentityFormatter(_bindDnFormatter).SetLogger(_logger));
 
                 // first, we need to update device state and state reason.

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/ActiveDirectory/ExchangeActiveSync/ExchangeActiveSyncDevicesSearcher.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/ActiveDirectory/ExchangeActiveSync/ExchangeActiveSyncDevicesSearcher.cs
@@ -1,4 +1,5 @@
 ﻿using LdapForNet;
+using Microsoft.Extensions.Caching.Memory;
 using MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
 using MultiFactor.SelfService.Linux.Portal.Core.LdapFilterBuilding;
 using MultiFactor.SelfService.Linux.Portal.Integrations.ActiveDirectory.ExchangeActiveSync.Models;
@@ -18,6 +19,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.ActiveDirectory.Exch
         private readonly ILogger<ExchangeActiveSyncDevicesSearcher> _logger;
         private readonly IBindIdentityFormatter _bindDnFormatter;
         private readonly ILdapConnectionAdapter _ldapConnectionAdapter;
+        private readonly IMemoryCache _memoryCache;
         private readonly LdapProfileLoader _profileLoader;
 
         public ExchangeActiveSyncDevicesSearcher(PortalSettings settings, 
@@ -25,6 +27,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.ActiveDirectory.Exch
             ILogger<ExchangeActiveSyncDevicesSearcher> logger,
             IBindIdentityFormatter bindDnFormatter,
             ILdapConnectionAdapter ldapConnectionAdapter,
+            IMemoryCache memoryCache,
             LdapProfileLoader profileLoader)
         {
             _settings = settings;
@@ -48,6 +51,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.ActiveDirectory.Exch
                     _settings.CompanySettings.Domain, 
                     techUser, 
                     _settings.TechnicalAccountSettings.Password!,
+                    _memoryCache,
                     config => config.SetBindIdentityFormatter(_bindDnFormatter).SetLogger(_logger));
 
                 var domain = await connection.WhereAmIAsync();
@@ -99,6 +103,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.ActiveDirectory.Exch
                     _settings.CompanySettings.Domain, 
                     techUser, 
                     _settings.TechnicalAccountSettings.Password!,
+                    _memoryCache,
                     config => config.SetBindIdentityFormatter(_bindDnFormatter).SetLogger(_logger));
 
                 var domain = await connection.WhereAmIAsync();

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/Connection/LdapConnectionAdapterFactory.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/Connection/LdapConnectionAdapterFactory.cs
@@ -1,4 +1,5 @@
 ﻿using LdapForNet;
+using Microsoft.Extensions.Caching.Memory;
 using MultiFactor.SelfService.Linux.Portal.Abstractions.Ldap;
 using MultiFactor.SelfService.Linux.Portal.Core.LdapFilterBuilding;
 using MultiFactor.SelfService.Linux.Portal.Exceptions;
@@ -12,17 +13,20 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection
         private readonly ILogger<LdapConnectionAdapterFactory> _logger;
         private readonly IBindIdentityFormatter _bindDnFormatter;
         private readonly ILdapConnectionAdapter _ldapConnectionAdapter;
-        
+        private readonly IMemoryCache _memoryCache;
+
         public LdapConnectionAdapterFactory(
             PortalSettings settings, 
             ILogger<LdapConnectionAdapterFactory> logger, 
             IBindIdentityFormatter bindDnFormatter,
-            ILdapConnectionAdapter ldapConnectionAdapter)
+            ILdapConnectionAdapter ldapConnectionAdapter,
+            IMemoryCache memoryCache)
         {
             _settings = settings;
             _logger = logger;
             _bindDnFormatter = bindDnFormatter;
             _ldapConnectionAdapter = ldapConnectionAdapter;
+            _memoryCache = memoryCache ?? throw new ArgumentNullException(nameof(memoryCache));
         }
 
         /// <summary>
@@ -45,6 +49,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection
                     _settings.CompanySettings.Domain,
                     parsed,
                     password,
+                    _memoryCache,
                     config => config.SetBindIdentityFormatter(_bindDnFormatter));
             }
 
@@ -55,6 +60,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection
                 _settings.CompanySettings.Domain,
                 existedUser,
                 password,
+                _memoryCache,
                 config => config.SetBindIdentityFormatter(_bindDnFormatter).SetLogger(_logger));
         }
 
@@ -75,6 +81,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection
                     _settings.CompanySettings.Domain,
                     user,
                     _settings.TechnicalAccountSettings.Password!,
+                    _memoryCache,
                     config => config.SetBindIdentityFormatter(_bindDnFormatter).SetLogger(_logger));
             }
             catch (Exception ex)

--- a/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/Connection/LdapServerInfoFactory.cs
+++ b/src/MultiFactor.SelfService.Linux.Portal/Integrations/Ldap/Connection/LdapServerInfoFactory.cs
@@ -1,4 +1,5 @@
-﻿using MultiFactor.SelfService.Linux.Portal.Settings;
+﻿using Microsoft.Extensions.Caching.Memory;
+using MultiFactor.SelfService.Linux.Portal.Settings;
 
 namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection
 {
@@ -7,11 +8,13 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection
         private readonly PortalSettings _settings;
         private readonly ILogger<LdapServerInfoFactory> _logger;
         private readonly ILdapConnectionAdapter _ldapConnectionAdapter;
+        private readonly IMemoryCache _memoryCache;
 
-        public LdapServerInfoFactory(PortalSettings settings, ILdapConnectionAdapter ldapConnectionAdapter, ILogger<LdapServerInfoFactory> logger)
+        public LdapServerInfoFactory(PortalSettings settings, ILdapConnectionAdapter ldapConnectionAdapter, ILogger<LdapServerInfoFactory> logger, IMemoryCache memoryCache)
         {
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _memoryCache = memoryCache ?? throw new ArgumentNullException(nameof(memoryCache));
             _ldapConnectionAdapter = ldapConnectionAdapter;
         }
 
@@ -20,6 +23,7 @@ namespace MultiFactor.SelfService.Linux.Portal.Integrations.Ldap.Connection
             try
             {
                 using var conn = _ldapConnectionAdapter.CreateAnonymous(_settings.CompanySettings.Domain,
+                    _memoryCache,
                     x => x.SetLogger(_logger));
                 var info = await conn.GetServerInfoAsync();
                 _logger.LogInformation("Ldap implementation: {impl}", info);


### PR DESCRIPTION


### New

- Added queries profiling for LdapConnectionAdapter:
  - Profiling will be logged in 'Debug' log level.
  - Example of configuration file section with log level set to 'Debug':
```
<Logging>
	<LogLevel>
		<Default>Debug</Default>
	</LogLevel>
</Logging>
```
- Added caching of domain search ldap query